### PR TITLE
feat(#11, #20 ): User 회원가입, User 로그인

### DIFF
--- a/healthtart/build.gradle
+++ b/healthtart/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.modelmapper:modelmapper:3.1.1'
 
+    // import jakarta.ws.rs.core.HttpHeaders; 이 라이브러리 사용 위함 -> 기존에는 eureka-client에 있었음.
+    implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
+
     // jwt token을 위한 옵션
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/AuthenticationFilter.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/AuthenticationFilter.java
@@ -1,88 +1,92 @@
-//package com.dev5ops.healthtart.secutiry;
-//
-//import com.dev5ops.healthtart.user.service.UserService;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import io.jsonwebtoken.Claims;
-//import io.jsonwebtoken.Jwts;
-//import io.jsonwebtoken.SignatureAlgorithm;
-//import jakarta.servlet.FilterChain;
-//import jakarta.servlet.ServletException;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//import jakarta.ws.rs.core.HttpHeaders;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.core.env.Environment;
-//import org.springframework.security.authentication.AuthenticationManager;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.Authentication;
-//import org.springframework.security.core.AuthenticationException;
-//import org.springframework.security.core.userdetails.User;
-//import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-//
-//import java.io.IOException;
-//import java.util.ArrayList;
-//import java.util.Date;
-//import java.util.List;
-//import java.util.stream.Collectors;
-//
-//@Slf4j
-//public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
-//
-//    private UserService userService;
-//    private Environment env;
-//
-//    public AuthenticationFilter(AuthenticationManager authenticationManager, UserService userService, Environment env) {
-//        super(authenticationManager);
-//        this.userService = userService;
-//        this.env = env;
-//    }
-//
-//    /* 설명. 로그인 시도 시 동작하는 기능(POST /login 요청 시) */
-//    @Override
-//    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
-//
-//        /* 설명. request body에 담긴 내용을 우리가 만든 RequestLoginVO 타입에 담는다.(일종의 @RequestBody의 개념) */
-//        try {
-//            RequestLoginVO creds = new ObjectMapper().readValue(request.getInputStream(), RequestLoginVO.class);
-//
-//            return getAuthenticationManager().authenticate(
-//                    new UsernamePasswordAuthenticationToken(creds.getUserEmail(), creds.getUserPassword(), new ArrayList<>())
-//            );
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//    }
-//
-//    /* 설명. 로그인 성공 시 JWT 토큰 생성하는 기능 */
-//    @Override
-//    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
-//
-//        log.info("로그인 성공하고 security가 관리하는 principal 객체(authResult): {}", authResult);
-//
-//        /* 설명. 로그인 이후 관리되고 있는 Authentication 객체를 활용해 JWT Token 만들기 */
-//        log.info("시크릿 키: " + env.getProperty("token.secret"));
-//
-//        /* 설명. 토큰의 payload에 어떤 값을 담고 싶은지에 따라 고민해서 재료를 수집한다.(id, 가진 권한들, 만료시간) */
-//        String userName = ((User)authResult.getPrincipal()).getUsername();  // id의 개념(우리는 email로 작성했음)
-//        log.info("인증된 회원의 id: " + userName);
-//
-//        /* 설명. 권한들을 꺼내 List<String>로 변환 */
-//        List<String> roles = authResult.getAuthorities().stream()
-//                .map(role -> role.getAuthority())
-//                .collect(Collectors.toList());
-//
-//        /* 설명. 재료들로 토큰 만들기(Jwt Token 라이브러리 추가(3가지)하기) */
-//        Claims claims = Jwts.claims().setSubject(userName);
-//        claims.put("auth", roles);      // 비공개 클레임은 Claims에서 제공하는 put을 활용해 추가한다.
-//
-//        String token = Jwts.builder()
-//                .setClaims(claims)
-//                .setExpiration(new Date(System.currentTimeMillis()
-//                        + Long.parseLong(env.getProperty("token.expiration_time"))))
-//                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.secret"))
-//                .compact();
-//
-////        response.addHeader("token", token);
-//        response.addHeader(HttpHeaders.AUTHORIZATION, token);
-//    }
-//}
+package com.dev5ops.healthtart.secutiry;
+
+import com.dev5ops.healthtart.user.domain.vo.request.RequestLoginVO;
+import com.dev5ops.healthtart.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.HttpHeaders;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private UserService userService;
+    private Environment env;
+
+    public AuthenticationFilter(AuthenticationManager authenticationManager, UserService userService, Environment env) {
+        super(authenticationManager);
+        this.userService = userService;
+        this.env = env;
+
+        // 커스텀 로그인 경로 설정
+        setFilterProcessesUrl("/users/login");
+    }
+
+    /* 설명. 로그인 시도 시 동작하는 기능(POST /login 요청 시) */
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        /* 설명. request body에 담긴 내용을 우리가 만든 RequestLoginVO 타입에 담는다.(일종의 @RequestBody의 개념) */
+        try {
+            RequestLoginVO creds = new ObjectMapper().readValue(request.getInputStream(), RequestLoginVO.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(creds.getUserEmail(), creds.getUserPassword(), new ArrayList<>())
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /* 설명. 로그인 성공 시 JWT 토큰 생성하는 기능 */
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+
+        log.info("로그인 성공하고 security가 관리하는 principal 객체(authResult): {}", authResult);
+
+        /* 설명. 로그인 이후 관리되고 있는 Authentication 객체를 활용해 JWT Token 만들기 */
+        log.info("시크릿 키: " + env.getProperty("token.secret"));
+
+        /* 설명. 토큰의 payload에 어떤 값을 담고 싶은지에 따라 고민해서 재료를 수집한다.(id, 가진 권한들, 만료시간) */
+        String userName = ((User)authResult.getPrincipal()).getUsername();  // id의 개념(우리는 email로 작성했음)
+        log.info("인증된 회원의 id: " + userName);
+
+        /* 설명. 권한들을 꺼내 List<String>로 변환 */
+        List<String> roles = authResult.getAuthorities().stream()
+                .map(role -> role.getAuthority())
+                .collect(Collectors.toList());
+
+        /* 설명. 재료들로 토큰 만들기(Jwt Token 라이브러리 추가(3가지)하기) */
+        Claims claims = Jwts.claims().setSubject(userName);
+        claims.put("auth", roles);      // 비공개 클레임은 Claims에서 제공하는 put을 활용해 추가한다.
+
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(new Date(System.currentTimeMillis()
+                        + Long.parseLong(env.getProperty("token.expiration_time"))))
+                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.secret"))
+                .compact();
+
+//        response.addHeader("token", token);
+        response.addHeader(HttpHeaders.AUTHORIZATION, token);
+    }
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/JwtFilter.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/JwtFilter.java
@@ -1,50 +1,50 @@
-//package com.dev5ops.healthtart.secutiry;
-//
-//
-//import com.dev5ops.healthtart.user.service.UserService;
-//import jakarta.servlet.FilterChain;
-//import jakarta.servlet.ServletException;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.security.core.Authentication;
-//import org.springframework.security.core.context.SecurityContextHolder;
-//import org.springframework.web.filter.OncePerRequestFilter;
-//
-//import java.io.IOException;
-//
-//@Slf4j
-///* 설명. OncePerRequestFilter를 상속받아 doFilterInternal을 오버라이딩 한다.(한번만 실행되는 필터) */
-//public class JwtFilter extends OncePerRequestFilter {
-//
-//    private final UserService userService;
-//    private final JwtUtil jwtUtil;
-//
-//    public JwtFilter(UserService userService, JwtUtil jwtUtil) {
-//        this.userService = userService;
-//        this.jwtUtil = jwtUtil;
-//    }
-//
-//    /* 설명. 들고 온(Request Header) 토큰이 유효한지 판별 및 인증(Authentication 객체로 관리) */
-//    @Override
-//    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-//        log.info("UsernamePasswordAuthenticationFilter보다 먼저 동작하는 필터");
-//
-//        String authorizationHeader = request.getHeader("Authorization");
-//        log.info("Authorization header: {}", authorizationHeader);
-//
-//        /* 설명. JWT 토큰이 Request Header에 있는 경우(로그인 이후 요청일 경우) */
-//        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-//            String token = authorizationHeader.substring(7);    // "Bearer "를 제외한 뒤에 토큰 부분만 추출
-//            log.info("토큰 값: " + token);
-//            if(jwtUtil.validateToken(token)) {
-//                Authentication authentication = jwtUtil.getAuthentication(token);
-//                log.info("JwtFilter를 통과한 유효한 토큰을 통해 security가 관리할 principal 객체: {}", authentication);
-//                SecurityContextHolder.getContext().setAuthentication(authentication);   // 인증이 완료되었고 이후 필터 건너뜀
-//            }
-//        }
-//
-//        /* 설명. 위의 if문으로 인증된 Authentication 객체가 principal 객체로 관리되지 않는다면 다음 필터 실행 */
-//        filterChain.doFilter(request, response);    // 실행 될 다음 필터는 UsernamePasswordAuthenticationFilter
-//    }
-//}
+package com.dev5ops.healthtart.secutiry;
+
+
+import com.dev5ops.healthtart.user.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+/* 설명. OncePerRequestFilter를 상속받아 doFilterInternal을 오버라이딩 한다.(한번만 실행되는 필터) */
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(UserService userService, JwtUtil jwtUtil) {
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    /* 설명. 들고 온(Request Header) 토큰이 유효한지 판별 및 인증(Authentication 객체로 관리) */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("UsernamePasswordAuthenticationFilter보다 먼저 동작하는 필터");
+
+        String authorizationHeader = request.getHeader("Authorization");
+        log.info("Authorization header: {}", authorizationHeader);
+
+        /* 설명. JWT 토큰이 Request Header에 있는 경우(로그인 이후 요청일 경우) */
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);    // "Bearer "를 제외한 뒤에 토큰 부분만 추출
+            log.info("토큰 값: " + token);
+            if(jwtUtil.validateToken(token)) {
+                Authentication authentication = jwtUtil.getAuthentication(token);
+                log.info("JwtFilter를 통과한 유효한 토큰을 통해 security가 관리할 principal 객체: {}", authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);   // 인증이 완료되었고 이후 필터 건너뜀
+            }
+        }
+
+        /* 설명. 위의 if문으로 인증된 Authentication 객체가 principal 객체로 관리되지 않는다면 다음 필터 실행 */
+        filterChain.doFilter(request, response);    // 실행 될 다음 필터는 UsernamePasswordAuthenticationFilter
+    }
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/JwtUtil.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/JwtUtil.java
@@ -1,92 +1,92 @@
-//package com.dev5ops.healthtart.secutiry;
-//
-//import io.jsonwebtoken.*;
-//import io.jsonwebtoken.io.Decoders;
-//import io.jsonwebtoken.security.Keys;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.Authentication;
-//import org.springframework.security.core.GrantedAuthority;
-//import org.springframework.security.core.authority.SimpleGrantedAuthority;
-//import org.springframework.security.core.userdetails.UserDetails;
-//import org.springframework.stereotype.Component;
-//
-//import java.security.Key;
-//import java.util.Arrays;
-//import java.util.Collection;
-//import java.util.Date;
-//import java.util.stream.Collectors;
-//
-//@Slf4j
-//@Component
-//public class JwtUtil {
-//
-//    private final Key secretKey;
-//    private long expirationTime;
-//
-//    public JwtUtil(@Value("${token.secret}") String secretKey, @Value("${token.expiration_time}") long expirationTime) {
-//        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
-//        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
-//        this.expirationTime = expirationTime;
-//    }
-//
-//    /* 설명. Token 검증(Bearer 토큰이 넘어왔고, 우리 사이트의 secret key로 만들어 졌는가, 만료되었는지와 내용이 비어있진 않은지) */
-//    public boolean validateToken(String token) {
-//        try {
-//            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
-//            return true;
-//        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-//            log.info("Invalid JWT Token {}", e);
-//        } catch (ExpiredJwtException e) {
-//            log.info("Expired JWT Token {}", e);
-//        } catch (UnsupportedJwtException e) {
-//            log.info("Unsupported JWT Token {}", e);
-//        } catch (IllegalArgumentException e) {
-//            log.info("JWT Token claims empty {}", e);
-//        }
-//
-//        return false;
-//    }
-//
-//    /* 설명. 넘어온 AccessToken으로 인증 객체 추출 */
-//    public Authentication getAuthentication(String token) {
-//
-//        /* 설명. 토큰에서 claim들 추출 */
-//        Claims claims = parseClaims(token);
-//        log.info("넘어온 AccessToken claims 확인: {}", claims);
-//
-//        // JWT 토큰에서 subject를 가져와 사용자 ID로 사용
-//        String userId = claims.getSubject();
-//
-//        Collection<? extends GrantedAuthority> authorities = null;
-//        if (claims.get("auth") == null) {
-//            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
-//        } else {
-//            /* 설명. 클레임에서 권한 정보들 가져오기 */
-//            authorities = Arrays.stream(claims.get("auth").toString()
-//                            .replace("[", "")
-//                            .replace("]", "")
-//                            .split(", "))
-//                    .map(role -> new SimpleGrantedAuthority(role))
-//                    .collect(Collectors.toList());
-//        }
-//
-//        // SecurityContext에 인증 정보를 저장하기 위해 Authentication 객체 반환
-//        return new UsernamePasswordAuthenticationToken(userId, "", authorities);
-//    }
-//
-//
-//    /* 설명. Token에서 Claims 추출 */
-//    public Claims parseClaims(String token) {
-//        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
-//    }
-//
-//    /* 설명. Token에서 사용자의 id(subject 클레임) 추출 */
-//    public String getUserId(String token) {
-//        return parseClaims(token).getSubject();
-//    }
-//
+package com.dev5ops.healthtart.secutiry;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final Key secretKey;
+    private long expirationTime;
+
+    public JwtUtil(@Value("${token.secret}") String secretKey, @Value("${token.expiration_time}") long expirationTime) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        this.expirationTime = expirationTime;
+    }
+
+    /* 설명. Token 검증(Bearer 토큰이 넘어왔고, 우리 사이트의 secret key로 만들어 졌는가, 만료되었는지와 내용이 비어있진 않은지) */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token {}", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token {}", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token {}", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT Token claims empty {}", e);
+        }
+
+        return false;
+    }
+
+    /* 설명. 넘어온 AccessToken으로 인증 객체 추출 */
+    public Authentication getAuthentication(String token) {
+
+        /* 설명. 토큰에서 claim들 추출 */
+        Claims claims = parseClaims(token);
+        log.info("넘어온 AccessToken claims 확인: {}", claims);
+
+        // JWT 토큰에서 subject를 가져와 사용자 ID로 사용
+        String userId = claims.getSubject();
+
+        Collection<? extends GrantedAuthority> authorities = null;
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        } else {
+            /* 설명. 클레임에서 권한 정보들 가져오기 */
+            authorities = Arrays.stream(claims.get("auth").toString()
+                            .replace("[", "")
+                            .replace("]", "")
+                            .split(", "))
+                    .map(role -> new SimpleGrantedAuthority(role))
+                    .collect(Collectors.toList());
+        }
+
+        // SecurityContext에 인증 정보를 저장하기 위해 Authentication 객체 반환
+        return new UsernamePasswordAuthenticationToken(userId, "", authorities);
+    }
+
+
+    /* 설명. Token에서 Claims 추출 */
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+    }
+
+    /* 설명. Token에서 사용자의 id(subject 클레임) 추출 */
+    public String getUserId(String token) {
+        return parseClaims(token).getSubject();
+    }
+
 //    public String kakaoGenerateToken(KakaoUserDTO userDTO) {
 //        Claims claims = Jwts.claims().setSubject(userDTO.getUserCode());
 //        claims.put("email", userDTO.getUserEmail());
@@ -99,4 +99,4 @@
 //                .signWith(SignatureAlgorithm.HS512, secretKey)
 //                .compact();
 //    }
-//}
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/WebSecurity.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/secutiry/WebSecurity.java
@@ -1,0 +1,76 @@
+package com.dev5ops.healthtart.secutiry;
+
+import com.dev5ops.healthtart.user.service.UserService;
+import jakarta.servlet.Filter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurity {
+
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+    private UserService userService;
+    private Environment env;
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    public WebSecurity(BCryptPasswordEncoder bCryptPasswordEncoder, UserService userService, Environment env, JwtUtil jwtUtil) {
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.userService = userService;
+        this.env = env;
+        this.jwtUtil = jwtUtil;
+    }
+
+    /* 설명. 인가(Authoriazation)용 메소드(인증 필터 추가) */
+    @Bean
+    protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
+
+        http.csrf((csrf) -> csrf.disable());
+
+        /* 로그인 시 추가할 authenticationManager */
+        AuthenticationManagerBuilder authenticationManagerBuilder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder.userDetailsService(userService)
+                .passwordEncoder(bCryptPasswordEncoder);
+
+        AuthenticationManager authenticationManager = authenticationManagerBuilder.build();
+
+        http.authorizeHttpRequests((authz) ->
+                                authz
+                                        .requestMatchers(new AntPathRequestMatcher("/users/**", "POST")).permitAll()
+                                        .requestMatchers(new AntPathRequestMatcher("/users/**", "GET")).permitAll()
+                                        .requestMatchers(new AntPathRequestMatcher("/users/**", "PATCH")).permitAll()
+
+                                        .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**")).permitAll()
+                                        .requestMatchers(new AntPathRequestMatcher("/v3/api-docs/**")).permitAll()
+                                        .anyRequest().authenticated()
+                )
+                /* UserDetails를 상속받는 Service 계층 + BCrypt 암호화 */
+                .authenticationManager(authenticationManager)
+
+                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.addFilter(getAuthenticationFilter(authenticationManager));
+        http.addFilterBefore(new JwtFilter(userService, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    /* Authentication 용 메소드(인증 필터 반환) */
+    private Filter getAuthenticationFilter(AuthenticationManager authenticationManager) {
+        return new AuthenticationFilter(authenticationManager, userService, env);
+    }
+
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.dev5ops.healthtart.user.controller;
 
 //import com.dev5ops.healthtart.secutiry.JwtUtil;
+import com.dev5ops.healthtart.user.domain.dto.UserDTO;
 import com.dev5ops.healthtart.user.domain.vo.request.RequestInsertUserVO;
 import com.dev5ops.healthtart.user.domain.vo.response.ResponseInsertUserVO;
 import com.dev5ops.healthtart.user.service.UserService;
@@ -11,10 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("users")
@@ -22,22 +22,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
 //    private JwtUtil jwtUtil;
-    private Environment env;
+//    private Environment env;
     private ModelMapper modelMapper;
     private UserService userService;
 
     @Autowired
-    public UserController(/*JwtUtil jwtUtil,*/ Environment env, ModelMapper modelMapper, UserService userService) {
+    public UserController(/*JwtUtil jwtUtil,*//* Environment env,*/ ModelMapper modelMapper, UserService userService) {
 //        this.jwtUtil = jwtUtil;
-        this.env = env;
+//        this.env = env;
         this.modelMapper = modelMapper;
         this.userService = userService;
     }
 
+    @GetMapping
+    public ResponseEntity<List<UserDTO>> findAllUsers () {
+        List<UserDTO> allUsers = userService.findAllUsers();
+
+        return ResponseEntity.status(HttpStatus.OK).body(allUsers);
+    }
+
     @PostMapping // /users 와 POST 요청은 회원가입 (필요한 데이터가 뭐가 있을까?) -> RequestInsertUserVO
-    public ResponseEntity<ResponseInsertUserVO> registerUser(@RequestBody RequestInsertUserVO request) {
+    public ResponseEntity<ResponseInsertUserVO> insertUser(@RequestBody RequestInsertUserVO request) {
         ResponseInsertUserVO responseUser = userService.signUpUser(request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(responseUser);
     }
+
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/dto/UserDTO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/dto/UserDTO.java
@@ -1,10 +1,7 @@
 package com.dev5ops.healthtart.user.domain.dto;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +9,7 @@ import java.time.LocalDateTime;
 @Setter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserDTO {
 
     private String userCode;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/vo/request/RequestInsertUserVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/vo/request/RequestInsertUserVO.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 public class RequestInsertUserVO {
 
-    // Integer userCode;
+    // String userCode;
     String userType; // 이미 정해진 정보
     String userName;
     String userEmail;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/vo/request/RequestLoginVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/vo/request/RequestLoginVO.java
@@ -1,0 +1,13 @@
+package com.dev5ops.healthtart.user.domain.vo.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class RequestLoginVO {
+    private String userEmail;
+    private String userPassword;
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/repository/UserRepository.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUserEmail(String userEmail);
 
 
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/service/UserService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/service/UserService.java
@@ -7,59 +7,19 @@ import com.dev5ops.healthtart.user.domain.vo.response.ResponseInsertUserVO;
 import com.dev5ops.healthtart.user.repository.UserRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
-public class UserService {
+public interface UserService extends UserDetailsService {
+    public ResponseInsertUserVO signUpUser(RequestInsertUserVO request);
 
-    private UserRepository userRepository;
-    private ModelMapper modelMapper;
-    private BCryptPasswordEncoder bCryptPasswordEncoder;
-
-    public UserService(UserRepository userRepository, ModelMapper modelMapper, BCryptPasswordEncoder bCryptPasswordEncoder) {
-        this.userRepository = userRepository;
-        this.modelMapper = modelMapper;
-        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
-    }
-
-    // 이건 회원가입을 하는 코드. -> 일단 일반 회원부터 처리해보자.
-    public ResponseInsertUserVO signUpUser(RequestInsertUserVO request) {
-
-        // Redis에서 이메일 인증 여부 확인
-//        String emailVerificationStatus = stringRedisTemplate.opsForValue().get(requestRegisterUserVO.getUserEmail());
-        // -> 레디스 이메일 인증 처리는 일반회원만 해야한다.
-
-        String curDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        String uuid = UUID.randomUUID().toString();
-
-        String userCode = curDate + uuid.substring(0);
-
-        request.changePwd(bCryptPasswordEncoder.encode(request.getUserPassword()));
-
-        UserDTO userDTO = UserDTO.builder()
-                .userCode(userCode)
-                .userType(request.getUserType())
-                .userName(request.getUserName())
-                .userEmail(request.getUserEmail())
-                .userPassword(request.getUserPassword())
-                .userPhone(request.getUserPhone())
-                .nickname(request.getNickname())
-                .userAddress(request.getUserAddress())
-                .userFlag(true)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build(); // gym은 비워놓기
-
-        User insertUser = modelMapper.map(userDTO, User.class);
-
-        userRepository.save(insertUser);
-
-
-        return new ResponseInsertUserVO(userDTO);
-    }
+    public List<UserDTO> findAllUsers();
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/service/UserServiceImpl.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/service/UserServiceImpl.java
@@ -1,0 +1,110 @@
+package com.dev5ops.healthtart.user.service;
+
+import com.dev5ops.healthtart.user.domain.dto.UserDTO;
+import com.dev5ops.healthtart.user.domain.entity.User;
+import com.dev5ops.healthtart.user.domain.vo.request.RequestInsertUserVO;
+import com.dev5ops.healthtart.user.domain.vo.response.ResponseInsertUserVO;
+import com.dev5ops.healthtart.user.repository.UserRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class UserServiceImpl implements UserService{
+
+    private UserRepository userRepository;
+    private ModelMapper modelMapper;
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Autowired
+    public UserServiceImpl(UserRepository userRepository, ModelMapper modelMapper, BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.userRepository = userRepository;
+        this.modelMapper = modelMapper;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    // 이건 회원가입을 하는 코드. -> 일단 일반 회원부터 처리해보자.
+    @Override
+    public ResponseInsertUserVO signUpUser(RequestInsertUserVO request) {
+
+        // Redis에서 이메일 인증 여부 확인
+//        String emailVerificationStatus = stringRedisTemplate.opsForValue().get(requestRegisterUserVO.getUserEmail());
+        // -> 레디스 이메일 인증 처리는 일반회원만 해야한다.
+
+        String curDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uuid = UUID.randomUUID().toString();
+
+        String userCode = curDate + "-" + uuid.substring(0);
+
+        request.changePwd(bCryptPasswordEncoder.encode(request.getUserPassword()));
+
+        UserDTO userDTO = UserDTO.builder()
+                .userCode(userCode)
+                .userType(request.getUserType())
+                .userName(request.getUserName())
+                .userEmail(request.getUserEmail())
+                .userPassword(request.getUserPassword())
+                .userPhone(request.getUserPhone())
+                .nickname(request.getNickname())
+                .userAddress(request.getUserAddress())
+                .userFlag(true)
+                .userGender("M")
+                .userHeight(request.getUserHeight())
+                .userWeight(request.getUserWeight())
+                .userAge(request.getUserAge())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build(); // gym은 비워놓기
+
+        User insertUser = modelMapper.map(userDTO, User.class);
+
+        userRepository.save(insertUser);
+
+
+        return new ResponseInsertUserVO(userDTO);
+    }
+
+    @Override
+    public List<UserDTO> findAllUsers() {
+        List<User> allUsers = userRepository.findAll();
+        List<UserDTO> userDTOs = new ArrayList<>();
+
+        for (User user : allUsers) {
+            UserDTO userDTO = modelMapper.map(user, UserDTO.class);
+            userDTOs.add(userDTO);
+        }
+        return userDTOs;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
+        User loginUser = userRepository.findByUserEmail(userEmail);
+
+        // 밑에부분 예외처리 수정 필요
+        if (loginUser == null) {throw new UsernameNotFoundException(userEmail);}
+
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+
+        switch (loginUser.getUserType()) {
+            case MEMBER -> grantedAuthorities.add(new SimpleGrantedAuthority("MEMBER"));
+            case ADMIN -> {
+                grantedAuthorities.add(new SimpleGrantedAuthority("ADMIN"));
+                grantedAuthorities.add(new SimpleGrantedAuthority("MEMBER"));
+            }
+        }
+
+        // 여기서 사용되는 User는 우리의 User와 다름.
+        return new org.springframework.security.core.userdetails.User(loginUser.getUserEmail(), loginUser.getUserPassword(),  true, true, true, true, grantedAuthorities);
+    }
+}


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
기본 회원가입과 로그인 시에 jwt 토큰을 부여하도록 설정했습니다.  
밑에 이미지를 보면 로그인 후에 jwt 토큰을 부여하는것을 확인할 수 있습니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/b5f21df6-3ecf-4ba7-87ea-884e329924b8)

<br/>

## 🔧 앞으로의 과제

- 저희 서비스 자체 회원가입 및 로그인 처리는 완료했습니다.
- 추가적으로 자체 회원가입시 redis로 이메일 인증을 추가 해야 합니다.
- 두번째로 구글, 카카오 oAuth2 인증을 도입해야합니다.

  <br/>

close #20 