### PR TITLE
feat(#23): 운동기구 단 건 조회, 전체 조회 기능 추가, CRUD 테스트 추가

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/aggregate/vo/response/ResponseFindEquipmentVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/aggregate/vo/response/ResponseFindEquipmentVO.java
@@ -1,0 +1,20 @@
+package com.dev5ops.healthtart.exercise_equipment.aggregate.vo.response;
+
+import com.dev5ops.healthtart.equipment_per_gym.aggregate.EquipmentPerGym;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ResponseFindEquipmentVO {
+    private String exerciseEquipmentName;
+    private String bodyPart;
+    private String exerciseDescription;
+    private String exerciseImage;
+    private String recommendedVideo;
+    private List<EquipmentPerGym> equipmentPerGyms;
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/controller/ExerciseEquipmentController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/controller/ExerciseEquipmentController.java
@@ -7,12 +7,6 @@ import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.response.ResponseF
 import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.response.ResponseRegisterEquipmentVO;
 import com.dev5ops.healthtart.exercise_equipment.dto.ExerciseEquipmentDTO;
 import com.dev5ops.healthtart.exercise_equipment.service.ExerciseEquipmentService;
-import com.dev5ops.healthtart.gym.aggregate.vo.request.RequestEditGymVO;
-import com.dev5ops.healthtart.gym.aggregate.vo.request.RequestRegisterGymVO;
-import com.dev5ops.healthtart.gym.aggregate.vo.response.ResponseEditGymVO;
-import com.dev5ops.healthtart.gym.aggregate.vo.response.ResponseFindGymVO;
-import com.dev5ops.healthtart.gym.aggregate.vo.response.ResponseRegisterGymVO;
-import com.dev5ops.healthtart.gym.dto.GymDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/controller/ExerciseEquipmentController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/controller/ExerciseEquipmentController.java
@@ -3,6 +3,7 @@ package com.dev5ops.healthtart.exercise_equipment.controller;
 import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.request.RequestEditEquipmentVO;
 import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.request.RequestRegisterEquipmentVO;
 import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.response.ResponseEditEquipmentVO;
+import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.response.ResponseFindEquipmentVO;
 import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.response.ResponseRegisterEquipmentVO;
 import com.dev5ops.healthtart.exercise_equipment.dto.ExerciseEquipmentDTO;
 import com.dev5ops.healthtart.exercise_equipment.service.ExerciseEquipmentService;
@@ -80,5 +81,43 @@ public class ExerciseEquipmentController {
         exerciseEquipmentService.deleteEquipment(exerciseEquipmentCode);
 
         return ResponseEntity.ok("운동기구가 성공적으로 삭제되었습니다.");
+    }
+
+    @Operation(summary = "관리자, 유저 - 운동기구 단 건 조회")
+    @GetMapping("/{exerciseEquipmentCode}")
+    public ResponseEntity<ResponseFindEquipmentVO> getEquipment(@PathVariable("exerciseEquipmentCode") Long exerciseEquipmentCode) {
+        ExerciseEquipmentDTO equipmentDTO = exerciseEquipmentService.findEquipmentByEquipmentCode(exerciseEquipmentCode);
+
+        ResponseFindEquipmentVO response = new ResponseFindEquipmentVO(
+                equipmentDTO.getExerciseEquipmentName(),
+                equipmentDTO.getBodyPart(),
+                equipmentDTO.getExerciseDescription(),
+                equipmentDTO.getExerciseImage(),
+                equipmentDTO.getRecommendedVideo(),
+                equipmentDTO.getEquipmentPerGyms()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "관리자, 유저 - 운동기구 전체 조회")
+    @GetMapping("/equipmentList")
+    public ResponseEntity<List<ResponseFindEquipmentVO>> getEquipmentList() {
+        List<ExerciseEquipmentDTO> equipmentDTOList = exerciseEquipmentService.findAllEquipment();
+        List<ResponseFindEquipmentVO> responseList = new ArrayList<>();
+
+        for (ExerciseEquipmentDTO equipmentDTO : equipmentDTOList) {
+            ResponseFindEquipmentVO response = new ResponseFindEquipmentVO(
+                    equipmentDTO.getExerciseEquipmentName(),
+                    equipmentDTO.getBodyPart(),
+                    equipmentDTO.getExerciseDescription(),
+                    equipmentDTO.getExerciseImage(),
+                    equipmentDTO.getRecommendedVideo(),
+                    equipmentDTO.getEquipmentPerGyms()
+            );
+
+            responseList.add(response);
+        }
+        return ResponseEntity.ok(responseList);
     }
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentService.java
@@ -12,6 +12,8 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -49,5 +51,19 @@ public class ExerciseEquipmentService {
         ExerciseEquipment exerciseEquipment = exerciseEquipmentRepository.findById(exerciseEquipmentCode).orElseThrow(() -> new CommonException(StatusEnum.EQUIPMENT_NOT_FOUND));
 
         exerciseEquipmentRepository.delete(exerciseEquipment);
+    }
+
+    public ExerciseEquipmentDTO findEquipmentByEquipmentCode(Long exerciseEquipmentCode) {
+        ExerciseEquipment exerciseEquipment = exerciseEquipmentRepository.findById(exerciseEquipmentCode).orElseThrow(() -> new CommonException(StatusEnum.EQUIPMENT_NOT_FOUND));
+
+        return modelMapper.map(exerciseEquipment, ExerciseEquipmentDTO.class);
+    }
+
+    public List<ExerciseEquipmentDTO> findAllEquipment() {
+        List<ExerciseEquipment> exerciseEquipments = exerciseEquipmentRepository.findAll();
+
+        return exerciseEquipments.stream()
+                .map(exerciseEquipment -> modelMapper.map(exerciseEquipment, ExerciseEquipmentDTO.class))
+                .collect(Collectors.toList());
     }
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentService.java
@@ -19,17 +19,19 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service("exerciseEquipmentService")
 public class ExerciseEquipmentService {
+
     private final ExerciseEquipmentRepository exerciseEquipmentRepository;
     private final ModelMapper modelMapper;
 
     public ExerciseEquipmentDTO registerEquipment(ExerciseEquipmentDTO equipmentDTO) {
         ExerciseEquipment exerciseEquipment = modelMapper.map(equipmentDTO, ExerciseEquipment.class);
 
-        if (exerciseEquipmentRepository.findByExerciseEquipmentName(exerciseEquipment.getExerciseEquipmentName()).isPresent()) throw new CommonException(StatusEnum.EQUIPMENT_DUPLICATE);
+        if(exerciseEquipmentRepository.findByExerciseEquipmentName(exerciseEquipment.getExerciseEquipmentName()).isPresent()) throw new CommonException(StatusEnum.EQUIPMENT_DUPLICATE);
 
         exerciseEquipment = exerciseEquipmentRepository.save(exerciseEquipment);
         return modelMapper.map(exerciseEquipment, ExerciseEquipmentDTO.class);
     }
+
 
     public ExerciseEquipmentDTO editEquipment(Long exerciseEquipmentCode, RequestEditEquipmentVO request) {
         ExerciseEquipment exerciseEquipment = exerciseEquipmentRepository.findById(exerciseEquipmentCode).orElseThrow(() -> new CommonException(StatusEnum.EQUIPMENT_NOT_FOUND));

--- a/healthtart/src/main/java/com/dev5ops/healthtart/gym/service/GymService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/gym/service/GymService.java
@@ -12,7 +12,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/healthtart/src/test/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentServiceTests.java
+++ b/healthtart/src/test/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentServiceTests.java
@@ -1,0 +1,344 @@
+package com.dev5ops.healthtart.exercise_equipment.service;
+
+import com.dev5ops.healthtart.common.exception.CommonException;
+import com.dev5ops.healthtart.common.exception.StatusEnum;
+import com.dev5ops.healthtart.exercise_equipment.aggregate.ExerciseEquipment;
+import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.request.RequestEditEquipmentVO;
+import com.dev5ops.healthtart.exercise_equipment.aggregate.vo.request.RequestRegisterEquipmentVO;
+import com.dev5ops.healthtart.exercise_equipment.dto.ExerciseEquipmentDTO;
+import com.dev5ops.healthtart.exercise_equipment.repository.ExerciseEquipmentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ExerciseEquipmentServiceTests {
+
+    @Mock
+    private ExerciseEquipmentRepository exerciseEquipmentRepository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private ExerciseEquipmentService exerciseEquipmentService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("운동 기구 등록 성공")
+    @Test
+    void testRegisterEquipment_Success() {
+        // Given
+        ExerciseEquipmentDTO request = new ExerciseEquipmentDTO(
+                null,
+                "testName",
+                "testBodyPart",
+                "testDescription",
+                "testImage",
+                "testVideo",
+                null,
+                null,
+                null
+        );
+
+        ExerciseEquipment mockEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(1L)
+                .exerciseEquipmentName("testName")
+                .bodyPart("testBodyPart")
+                .exerciseDescription("testDescription")
+                .exerciseImage("testImage")
+                .recommendedVideo("testVideo")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .equipmentPerGyms(new ArrayList<>())
+                .build();
+
+        when(modelMapper.map(request, ExerciseEquipment.class)).thenReturn(mockEquipment);
+        when(exerciseEquipmentRepository.save(any(ExerciseEquipment.class))).thenReturn(mockEquipment);
+        when(modelMapper.map(mockEquipment, ExerciseEquipmentDTO.class)).thenReturn(new ExerciseEquipmentDTO(
+                1L, "testName", "testBodyPart", "testDescription", "testImage", "testVideo", LocalDateTime.now(), LocalDateTime.now(), new ArrayList<>()
+        ));
+
+        // When
+        ExerciseEquipmentDTO response = exerciseEquipmentService.registerEquipment(request);
+
+        // Then
+        assertNotNull(response);
+        assertEquals(1L, response.getExerciseEquipmentCode());
+        verify(exerciseEquipmentRepository, times(1)).save(any(ExerciseEquipment.class));
+    }
+
+    @DisplayName("운동 기구 등록 실패 - 중복된 장비명")
+    @Test
+    void testRegisterEquipment_Duplicate() {
+        // Given
+        RequestRegisterEquipmentVO request = new RequestRegisterEquipmentVO(
+                "testName",
+                "testBodyPart",
+                "testDescription",
+                "testImage",
+                "testVideo"
+        );
+
+        ExerciseEquipment existingEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(1L)
+                .exerciseEquipmentName("testName")
+                .bodyPart("testBodyPart")
+                .exerciseDescription("testDescription")
+                .exerciseImage("testImage")
+                .recommendedVideo("testVideo")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(exerciseEquipmentRepository.findByExerciseEquipmentName(request.getExerciseEquipmentName()))
+                .thenReturn(Optional.of(existingEquipment));
+
+        ExerciseEquipmentDTO mockEquipmentDTO = new ExerciseEquipmentDTO(
+                null, "testName", "testBodyPart", "testDescription", "testImage", "testVideo", null, null, null
+        );
+
+        when(modelMapper.map(any(RequestRegisterEquipmentVO.class), eq(ExerciseEquipmentDTO.class)))
+                .thenReturn(mockEquipmentDTO);
+
+        ExerciseEquipment exerciseEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(1L)
+                .exerciseEquipmentName(request.getExerciseEquipmentName())
+                .bodyPart(request.getBodyPart())
+                .exerciseDescription(request.getExerciseDescription())
+                .exerciseImage(request.getExerciseImage())
+                .recommendedVideo(request.getRecommendedVideo())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(modelMapper.map(any(ExerciseEquipmentDTO.class), eq(ExerciseEquipment.class))).thenReturn(exerciseEquipment);
+
+        // When & Then
+        CommonException exception = assertThrows(CommonException.class, () -> {
+            exerciseEquipmentService.registerEquipment(mockEquipmentDTO);
+        });
+
+        assertEquals(StatusEnum.EQUIPMENT_DUPLICATE, exception.getStatusEnum());
+        verify(exerciseEquipmentRepository, never()).save(any(ExerciseEquipment.class));
+    }
+
+    @DisplayName("운동 기구 수정 성공")
+    @Test
+    void testEditEquipment_Success() {
+        // Given
+        Long equipmentCode = 1L;
+        RequestEditEquipmentVO request = new RequestEditEquipmentVO(
+                "updated testName",
+                "testBodyPart",
+                "updated testDescription",
+                "updated testImage",
+                "updated testVideo",
+                new ArrayList<>()
+        );
+
+        ExerciseEquipment existingEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(equipmentCode)
+                .exerciseEquipmentName("testName")
+                .bodyPart("testBodyPart")
+                .exerciseDescription("testDescription")
+                .exerciseImage("testImage")
+                .recommendedVideo("testVideo")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(exerciseEquipmentRepository.findById(equipmentCode)).thenReturn(Optional.of(existingEquipment));
+
+        ExerciseEquipment updatedEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(equipmentCode)
+                .exerciseEquipmentName(request.getExerciseEquipmentName())
+                .bodyPart(request.getBodyPart())
+                .exerciseDescription(request.getExerciseDescription())
+                .exerciseImage(request.getExerciseImage())
+                .recommendedVideo(request.getRecommendedVideo())
+                .createdAt(existingEquipment.getCreatedAt())
+                .updatedAt(LocalDateTime.now())
+                .equipmentPerGyms(request.getEquipmentPerGyms())
+                .build();
+
+        when(exerciseEquipmentRepository.save(existingEquipment)).thenReturn(updatedEquipment);
+        when(modelMapper.map(updatedEquipment, ExerciseEquipmentDTO.class)).thenReturn(new ExerciseEquipmentDTO(
+                equipmentCode,
+                request.getExerciseEquipmentName(),
+                request.getBodyPart(),
+                request.getExerciseDescription(),
+                request.getExerciseImage(),
+                request.getRecommendedVideo(),
+                existingEquipment.getCreatedAt(),
+                LocalDateTime.now(),
+                request.getEquipmentPerGyms()
+        ));
+
+        // When
+        ExerciseEquipmentDTO result = exerciseEquipmentService.editEquipment(equipmentCode, request);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("updated testName", result.getExerciseEquipmentName());
+        assertNotNull(result.getUpdatedAt());
+        verify(exerciseEquipmentRepository, times(1)).save(existingEquipment);
+    }
+
+    @DisplayName("운동 기구 삭제 성공")
+    @Test
+    void testDeleteEquipment_Success() {
+        // Given
+        Long equipmentCode = 1L;
+        ExerciseEquipment existingEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(equipmentCode)
+                .exerciseEquipmentName("testName")
+                .bodyPart("testBodyPart")
+                .exerciseDescription("testDescription")
+                .exerciseImage("testImage")
+                .recommendedVideo("testVideo")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(exerciseEquipmentRepository.findById(equipmentCode)).thenReturn(Optional.of(existingEquipment));
+
+        // When
+        exerciseEquipmentService.deleteEquipment(equipmentCode);
+
+        // Then
+        verify(exerciseEquipmentRepository, times(1)).delete(existingEquipment);
+    }
+
+    @DisplayName("운동 기구 삭제 실패 - 장비를 찾을 수 없음")
+    @Test
+    void testDeleteEquipment_NotFound() {
+        // Given
+        Long equipmentCode = 1L;
+
+        when(exerciseEquipmentRepository.findById(equipmentCode)).thenReturn(Optional.empty());
+
+        // When & Then
+        CommonException exception = assertThrows(CommonException.class, () -> {
+            exerciseEquipmentService.deleteEquipment(equipmentCode);
+        });
+
+        assertEquals(StatusEnum.EQUIPMENT_NOT_FOUND, exception.getStatusEnum());
+        verify(exerciseEquipmentRepository, never()).delete(any(ExerciseEquipment.class));
+    }
+
+    @DisplayName("운동 기구 단 건 조회 성공")
+    @Test
+    void testFindEquipmentByEquipmentCode_Success() {
+        // Given
+        Long equipmentCode = 1L;
+        ExerciseEquipment existingEquipment = ExerciseEquipment.builder()
+                .exerciseEquipmentCode(equipmentCode)
+                .exerciseEquipmentName("testName")
+                .bodyPart("testBodyPart")
+                .exerciseDescription("testDescription")
+                .exerciseImage("testImage")
+                .recommendedVideo("testVideo")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(exerciseEquipmentRepository.findById(equipmentCode)).thenReturn(Optional.of(existingEquipment));
+
+        ExerciseEquipmentDTO mockDTO = new ExerciseEquipmentDTO(
+                equipmentCode,
+                existingEquipment.getExerciseEquipmentName(),
+                existingEquipment.getBodyPart(),
+                existingEquipment.getExerciseDescription(),
+                existingEquipment.getExerciseImage(),
+                existingEquipment.getRecommendedVideo(),
+                existingEquipment.getCreatedAt(),
+                existingEquipment.getUpdatedAt(),
+                new ArrayList<>()
+        );
+
+        when(modelMapper.map(existingEquipment, ExerciseEquipmentDTO.class)).thenReturn(mockDTO);
+
+        // When
+        ExerciseEquipmentDTO result = exerciseEquipmentService.findEquipmentByEquipmentCode(equipmentCode);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(equipmentCode, result.getExerciseEquipmentCode());
+        verify(exerciseEquipmentRepository, times(1)).findById(equipmentCode);
+    }
+
+    @DisplayName("운동 기구 단 건 조회 실패 - 장비를 찾을 수 없음")
+    @Test
+    void testFindEquipmentByEquipmentCode_NotFound() {
+        // Given
+        Long equipmentCode = 1L;
+
+        when(exerciseEquipmentRepository.findById(equipmentCode)).thenReturn(Optional.empty());
+
+        // When & Then
+        CommonException exception = assertThrows(CommonException.class, () -> {
+            exerciseEquipmentService.findEquipmentByEquipmentCode(equipmentCode);
+        });
+
+        assertEquals(StatusEnum.EQUIPMENT_NOT_FOUND, exception.getStatusEnum());
+        verify(exerciseEquipmentRepository, times(1)).findById(equipmentCode);
+    }
+
+    @DisplayName("운동 기구 전체 조회 성공")
+    @Test
+    void testFindAllEquipment_Success() {
+        // Given
+        List<ExerciseEquipment> equipmentList = new ArrayList<>();
+        equipmentList.add(ExerciseEquipment.builder()
+                .exerciseEquipmentCode(1L)
+                .exerciseEquipmentName("testName1")
+                .bodyPart("testBodyPart1")
+                .exerciseDescription("testDescription1")
+                .exerciseImage("testImage1")
+                .recommendedVideo("testVideo1")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build());
+        equipmentList.add(ExerciseEquipment.builder()
+                .exerciseEquipmentCode(2L)
+                .exerciseEquipmentName("testName2")
+                .bodyPart("testBodyPart2")
+                .exerciseDescription("testDescription2")
+                .exerciseImage("testImage2")
+                .recommendedVideo("testVideo2")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build());
+
+        when(exerciseEquipmentRepository.findAll()).thenReturn(equipmentList);
+
+        when(modelMapper.map(equipmentList.get(0), ExerciseEquipmentDTO.class)).thenReturn(new ExerciseEquipmentDTO(
+                1L, "testName1", "testBodyPart1", "testDescription1", "testImage1", "testVideo1", LocalDateTime.now(), LocalDateTime.now(), new ArrayList<>()));
+        when(modelMapper.map(equipmentList.get(1), ExerciseEquipmentDTO.class)).thenReturn(new ExerciseEquipmentDTO(
+                2L, "testName2", "testBodyPart2", "testDescription2", "testImage2", "testVideo2", LocalDateTime.now(), LocalDateTime.now(), new ArrayList<>()));
+
+        // When
+        List<ExerciseEquipmentDTO> result = exerciseEquipmentService.findAllEquipment();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        verify(exerciseEquipmentRepository, times(1)).findAll();
+    }
+}


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
운동기구 단 건 조회, 전체 조회, CRUD는 단위테스트 코드로 구현했습니다.

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- 헬스장 별 운동 기구에서의 ManyToOne N+1문제를 fetch join으로 해결하는 것을 할 생각입니다.

  <br/>

Close #23 
