### PR TITLE
feat(30,31,32,33): 유저별&날짜별 운동기록 조회 기능, 테스트코드 추가

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/common/exception/StatusEnum.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/common/exception/StatusEnum.java
@@ -20,6 +20,7 @@ public enum StatusEnum {
     USER_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     GYM_NOT_FOUND(404, HttpStatus.NOT_FOUND, "헬스장이 존재하지 않습니다."),
     EQUIPMENT_NOT_FOUND(404, HttpStatus.NOT_FOUND, "DB에 해당 운동기구 데이터가 존재하지 않습니다."),
+    DAY_NOT_FOUND(404, HttpStatus.NOT_FOUND,"해당 날짜에 운동한 기록이 존재하지 않습니다." ),
 
     INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다");
     private final int statusCode;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/aggregate/RecordPerUser.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/aggregate/RecordPerUser.java
@@ -1,47 +1,62 @@
 package com.dev5ops.healthtart.record_per_user.aggregate;
 
-import com.google.api.client.util.DateTime;
+import com.dev5ops.healthtart.user.domain.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 
 @Entity(name = "RecordPerUser")
 @Table(name = "record_per_user")
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Getter
+@Setter
+@Builder
 public class RecordPerUser {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="user_record_code")
+    @Column(name="user_record_code", nullable = false, unique = true)
     private Long userRecordCode;
 
-    @Column(name="day_of_exercise")
-    private DateTime dayOfExercise;
+    @Column(name="day_of_exercise", nullable = false)
+    private LocalDate dayOfExercise;
 
-    @Column(name="exercise_duration")
-    private DateTime exerciseDuration;
+    @Column(name="exercise_duration", nullable = false)
+    private LocalTime exerciseDuration;
 
-    @Column(name="ratings")
-    private int ratings;
-
-    @Column(name="record_flag")
+    @Column(name="record_flag", nullable = false)
     private boolean recordFlag;
 
-    @Column(name="created_at")
-    private DateTime createdAt;
+    @Column(name="created_at", nullable = false)
+    private LocalDateTime createdAt;
 
-    @Column(name="updated_at")
-    private DateTime updatedAt;
+    @Column(name="updated_at", nullable = false)
+    private LocalDateTime updatedAt;
 
-    @Column(name="user_code")
-    private String userCode;
+    @ManyToOne
+    @JoinColumn(name = "user_code", nullable = false)
+    private User userCode;
 
-    @Column(name="workout_per_routine_code")
+    @Column(name="workout_per_routine_code", nullable = false)
     private Long workoutPerRoutineCode;
 
+
+    @Override
+    public String toString() {
+        return "RecordPerUser{" +
+                "userRecordCode=" + userRecordCode +
+                ", dayOfExercise=" + dayOfExercise +
+                ", exerciseDuration=" + exerciseDuration +
+                ", recordFlag=" + recordFlag +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", userCode=" + (userCode != null ? userCode.getUserCode() : null) +  // UserCode만 출력
+                ", workoutPerRoutineCode=" + workoutPerRoutineCode +
+                '}';
+    }
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/dto/RecordPerUserDTO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/dto/RecordPerUserDTO.java
@@ -1,12 +1,16 @@
 package com.dev5ops.healthtart.record_per_user.dto;
 
+import com.dev5ops.healthtart.user.domain.entity.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.api.client.util.DateTime;
 import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 @Getter
 @Setter
 public class RecordPerUserDTO {
@@ -15,27 +19,40 @@ public class RecordPerUserDTO {
     private Long userRecordCode;
 
     @JsonProperty("day_of_exercise")
-    private DateTime dayOfExercise;
+    private LocalDate dayOfExercise;
 
     @JsonProperty("exercise_duration")
-    private DateTime exerciseDuration;
-
-    @JsonProperty("ratings")
-    private int ratings;
+    private LocalTime exerciseDuration;
 
     @JsonProperty("record_flag")
     private boolean recordFlag;
 
     @JsonProperty("created_at")
-    private DateTime createdAt;
+    private LocalDateTime createdAt;
 
     @JsonProperty("updated_at")
-    private DateTime updatedAt;
+    private LocalDateTime updatedAt;
 
     @JsonProperty("user_code")
-    private String userCode;
+    private User userCode;
 
     @JsonProperty("workout_per_routine_code")
     private Long workoutPerRoutineCode;
 
+    @Override
+    public String toString() {
+        return "RecordPerUser{" +
+                "userRecordCode=" + userRecordCode +
+                ", dayOfExercise=" + dayOfExercise +
+                ", exerciseDuration=" + exerciseDuration +
+                ", recordFlag=" + recordFlag +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", userCode=" + (userCode != null ? userCode.getUserCode() : null) +
+                ", workoutPerRoutineCode=" + workoutPerRoutineCode +
+                '}';
+    }
+
 }
+
+

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/repository/RecordPerUserRepository.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/repository/RecordPerUserRepository.java
@@ -1,0 +1,16 @@
+package com.dev5ops.healthtart.record_per_user.repository;
+
+import com.dev5ops.healthtart.record_per_user.aggregate.RecordPerUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface RecordPerUserRepository extends JpaRepository<RecordPerUser, Integer> {
+    List<RecordPerUser> findByUser_UserCode(String userCode);
+    List<RecordPerUser> findByUser_UserCodeAndDayOfExercise(String userCode, LocalDate dayOfExercise);
+
+    boolean existsByUser_UserCode(String userCode);
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserService.java
@@ -1,0 +1,62 @@
+package com.dev5ops.healthtart.record_per_user.service;
+
+import com.dev5ops.healthtart.common.exception.CommonException;
+import com.dev5ops.healthtart.common.exception.StatusEnum;
+import com.dev5ops.healthtart.record_per_user.aggregate.RecordPerUser;
+import com.dev5ops.healthtart.record_per_user.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.repository.RecordPerUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service("recordPerUserService")
+public class RecordPerUserService {
+    private final RecordPerUserRepository recordPerUserRepository;
+    private final ModelMapper modelMapper;
+
+    // 조회 - (유저별운동기록)유저별 운동 기록 조회 - UserCode Join | 운동기록은 여러개 있을 수 있으니 List
+    public List<RecordPerUserDTO> findRecordByUserCode(String UserCode) {
+        List<RecordPerUser> recordPerUser = recordPerUserRepository.findByUser_UserCode(UserCode);
+
+        // 유저가 존재하지 않는다면 USER_NOT_FOUND
+        if (recordPerUser.isEmpty()) {
+            throw new CommonException(StatusEnum.USER_NOT_FOUND);
+        }
+
+        return recordPerUser.stream()
+                .filter(RecordPerUser::isRecordFlag)
+                .map(record -> modelMapper.map(record, RecordPerUserDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    // (유저별운동기록)날짜별 운동 기록 조회 - UserCode Join | 하루에 여러번 운동 할 수 있으니 List
+    public List<RecordPerUserDTO> findRecordPerDate(String UserCode, LocalDate dayOfExercise) {
+        List<RecordPerUser> recordPerUser = recordPerUserRepository
+                .findByUser_UserCodeAndDayOfExercise(UserCode, dayOfExercise);
+
+        if (recordPerUser.isEmpty()) {
+            boolean userExists = recordPerUserRepository.existsByUser_UserCode(UserCode);
+
+            // 유저가 존재하지 않으면 USER_NOT_FOUND
+            if (!userExists) {
+                throw new CommonException(StatusEnum.USER_NOT_FOUND);
+            }
+            // 유저는 존재하지만 그 날 운동한 기록이 없다면 DAY_NOT_FOUND
+            throw new CommonException(StatusEnum.DAY_NOT_FOUND);
+        }
+
+        return recordPerUser.stream()
+                .filter(RecordPerUser::isRecordFlag)
+                .map(record -> modelMapper.map(record, RecordPerUserDTO.class))
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/healthtart/src/test/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserServiceTests.java
+++ b/healthtart/src/test/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserServiceTests.java
@@ -1,0 +1,205 @@
+package com.dev5ops.healthtart.record_per_user.service;
+
+
+import com.dev5ops.healthtart.record_per_user.aggregate.RecordPerUser;
+import com.dev5ops.healthtart.record_per_user.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.repository.RecordPerUserRepository;
+import com.dev5ops.healthtart.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class RecordPerUserServiceTests {
+
+    @Mock
+    private RecordPerUserRepository recordPerUserRepository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private RecordPerUserService recordPerUserService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("유저별 운동 기록 조회 성공")
+    @Test
+    void findRecordByUserCode_Success() {
+
+        // given
+        String userCode = "testUserCode";
+        User mockUser = User.builder()
+                .userCode(userCode)
+                .build();
+
+        // 유저별 운동기록은 여러개일 수 있으니 2개의 기록으로 테스트
+        RecordPerUser mockFirstRecordPerUser = RecordPerUser.builder()
+                .userRecordCode(1L)
+                .dayOfExercise(LocalDate.of(2024,10,9))
+                .exerciseDuration(LocalTime.of(1,0,0))
+                .recordFlag(true)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .userCode(mockUser)
+                .workoutPerRoutineCode(1L)
+                .build();
+
+        RecordPerUser mockSecondRecordPerUser = RecordPerUser.builder()
+                .userRecordCode(2L)
+                .dayOfExercise(LocalDate.of(2024,10,10))
+                .exerciseDuration(LocalTime.of(1,0,0))
+                .recordFlag(true)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .userCode(mockUser)
+                .workoutPerRoutineCode(1L)
+                .build();
+
+        List<RecordPerUser> mockRecordsPerUser = Arrays
+                .asList(mockFirstRecordPerUser, mockSecondRecordPerUser);
+
+        RecordPerUserDTO mockFirstRecordPerUserDTO = new RecordPerUserDTO(1L
+                ,LocalDate.of(2024,10,9)
+                ,LocalTime.of(1,0,0)
+                ,true
+                ,LocalDateTime.now()
+                ,LocalDateTime.now()
+                ,mockUser
+                ,1L);
+
+        RecordPerUserDTO mockSecondRecordPerUserDTO = new RecordPerUserDTO(2L
+                ,LocalDate.of(2024,10,10)
+                ,LocalTime.of(1,0,0)
+                ,true
+                ,LocalDateTime.now()
+                ,LocalDateTime.now()
+                ,mockUser
+                ,1L);
+
+        List<RecordPerUserDTO> mockRecordsPerUserDTO = Arrays
+                .asList(mockFirstRecordPerUserDTO, mockSecondRecordPerUserDTO);
+
+        // when
+        when(recordPerUserRepository.findByUser_UserCode(userCode))
+                .thenReturn(mockRecordsPerUser);
+        when(modelMapper.map(mockFirstRecordPerUser, RecordPerUserDTO.class))
+                .thenReturn(mockFirstRecordPerUserDTO);
+        when(modelMapper.map(mockSecondRecordPerUser, RecordPerUserDTO.class))
+                .thenReturn(mockSecondRecordPerUserDTO);
+
+        List<RecordPerUserDTO> actual = recordPerUserService.findRecordByUserCode(userCode);
+
+        // then
+        assertNotNull(actual);
+        assertEquals(mockRecordsPerUserDTO, actual);
+
+        verify(recordPerUserRepository, times(1)).findByUser_UserCode(userCode);
+
+        // any - RecordPerUser의 어떤 객체여도 상관 없다 / eq - RecordPerUserDTO여야만 한다
+        verify(modelMapper, times(2)).map(any(RecordPerUser.class), eq(RecordPerUserDTO.class));
+
+    }
+
+    // findByUserCode_fail 테스트코드 작성
+
+    @DisplayName("날짜별 운동 기록 조회 성공")
+    @Test
+    void findRecordPerDate_Success() {
+
+        // given
+        String userCode = "testUserCode";
+        User mockUser = User.builder()
+                .userCode(userCode)
+                .build();
+
+        LocalDate dayOfExercise = LocalDate.of(2024, 10, 9);
+
+        RecordPerUser firstMockRecordPerUserAndDay = RecordPerUser.builder()
+                .userRecordCode(1L)
+                .dayOfExercise(LocalDate.of(2024,10,9))
+                .exerciseDuration(LocalTime.of(1,0,0))
+                .recordFlag(true)
+                .createdAt(LocalDateTime.now().withNano(0))
+                .updatedAt(LocalDateTime.now().withNano(0))
+                .userCode(mockUser)
+                .workoutPerRoutineCode(1L)
+                .build();
+
+        RecordPerUser secondMockRecordPerUserAndDay = RecordPerUser.builder()
+                .userRecordCode(2L)
+                .dayOfExercise(LocalDate.of(2024,10,9))
+                .exerciseDuration(LocalTime.of(1,0,0))
+                .recordFlag(true)
+                .createdAt(LocalDateTime.now().withNano(0))
+                .updatedAt(LocalDateTime.now().withNano(0))
+                .userCode(mockUser)
+                .workoutPerRoutineCode(1L)
+                .build();
+
+
+        List<RecordPerUser> mockRecordsPerUserAndDay = Arrays
+                .asList(firstMockRecordPerUserAndDay, secondMockRecordPerUserAndDay);
+
+
+        RecordPerUserDTO mockFirstRecordPerUserAndDayDTO = new RecordPerUserDTO(1L
+                ,LocalDate.of(2024,10,9)
+                ,LocalTime.of(1,0,0)
+                ,true
+                ,LocalDateTime.now().withNano(0)
+                ,LocalDateTime.now().withNano(0)
+                ,mockUser
+                ,1L);
+
+        RecordPerUserDTO mockSecondRecordPerUserAndDayDTO = new RecordPerUserDTO(2L
+                ,LocalDate.of(2024,10,9)
+                ,LocalTime.of(1,0,0)
+                ,true
+                ,LocalDateTime.now().withNano(0)
+                ,LocalDateTime.now().withNano(0)
+                ,mockUser
+                ,1L);
+
+
+        List<RecordPerUserDTO> mockRecordsPerUserAndDayDTO = Arrays
+                .asList(mockFirstRecordPerUserAndDayDTO, mockSecondRecordPerUserAndDayDTO);
+
+        // when
+        when(recordPerUserRepository.findByUser_UserCodeAndDayOfExercise(userCode, dayOfExercise))
+                .thenReturn(mockRecordsPerUserAndDay);
+        when(modelMapper.map(firstMockRecordPerUserAndDay, RecordPerUserDTO.class))
+                .thenReturn(mockFirstRecordPerUserAndDayDTO);
+        when(modelMapper.map(secondMockRecordPerUserAndDay, RecordPerUserDTO.class))
+                .thenReturn(mockSecondRecordPerUserAndDayDTO);
+
+        List<RecordPerUserDTO> actual = recordPerUserService.findRecordPerDate(userCode, dayOfExercise);
+
+        // then
+        assertNotNull(actual);
+        assertEquals(mockRecordsPerUserAndDayDTO, actual);
+
+        verify(recordPerUserRepository, times(1)).findByUser_UserCodeAndDayOfExercise(userCode, dayOfExercise);
+        verify(modelMapper, times(2)).map(any(RecordPerUser.class), eq(RecordPerUserDTO.class));
+
+    }
+
+
+}


### PR DESCRIPTION

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
- userCode로 운동기록 조회시 유저별 운동기록이 조회 되도록 했습니다.
- userCode와 dayOfExercise로 운동기록 조회시 유저의 날짜별 운동기록이 조회 되도록 했습니다.


  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/1fc5539f-37fd-49c3-a0ff-48fa68b19dab)


<br/>

## 🔧 앞으로의 과제

- 실패 했을 경우 예외처리가 제대로 터지는지에 대한 테스트 코드 작성
- CUD 구현

  <br/>
