### PR TITLE
운동기구에서의 부위 별 운동기구 조회 추가

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/controller/ExerciseEquipmentController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/controller/ExerciseEquipmentController.java
@@ -110,4 +110,24 @@ public class ExerciseEquipmentController {
         }
         return ResponseEntity.status(HttpStatus.OK).body(responseList);
     }
+
+    @Operation(summary = "관리자, 유저 - 운동 부위별 운동기구 조회")
+    @GetMapping("/by_body_part")
+    public ResponseEntity<List<ResponseFindEquipmentVO>> getEquipmentByBodyPart(@RequestParam("bodyPart") String bodyPart) {
+        List<ExerciseEquipmentDTO> equipmentDTOList = exerciseEquipmentService.findByBodyPart(bodyPart);
+        List<ResponseFindEquipmentVO> responseList = new ArrayList<>();
+
+        for (ExerciseEquipmentDTO equipmentDTO : equipmentDTOList) {
+            ResponseFindEquipmentVO response = new ResponseFindEquipmentVO(
+                    equipmentDTO.getExerciseEquipmentName(),
+                    equipmentDTO.getBodyPart(),
+                    equipmentDTO.getExerciseDescription(),
+                    equipmentDTO.getExerciseImage(),
+                    equipmentDTO.getRecommendedVideo()
+            );
+            responseList.add(response);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseList);
+    }
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/repository/ExerciseEquipmentRepository.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/repository/ExerciseEquipmentRepository.java
@@ -4,10 +4,13 @@ import com.dev5ops.healthtart.exercise_equipment.domain.entity.ExerciseEquipment
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ExerciseEquipmentRepository extends JpaRepository<ExerciseEquipment, Long> {
 
     Optional<ExerciseEquipment> findByExerciseEquipmentName(String exerciseEquipmentName);
+
+    List<ExerciseEquipment> findByBodyPart(String bodyPart);
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentService.java
@@ -70,4 +70,16 @@ public class ExerciseEquipmentService {
                 .map(exerciseEquipment -> modelMapper.map(exerciseEquipment, ExerciseEquipmentDTO.class))
                 .collect(Collectors.toList());
     }
+
+    public List<ExerciseEquipmentDTO> findByBodyPart(String bodyPart) {
+        List<ExerciseEquipment> equipmentList = exerciseEquipmentRepository.findByBodyPart(bodyPart);
+
+        if (equipmentList.isEmpty()) {
+            throw new CommonException(StatusEnum.EQUIPMENT_NOT_FOUND);
+        }
+
+        return equipmentList.stream()
+                .map(equipment -> modelMapper.map(equipment, ExerciseEquipmentDTO.class))
+                .collect(Collectors.toList());
+    }
 }

--- a/healthtart/src/test/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentServiceTests.java
+++ b/healthtart/src/test/java/com/dev5ops/healthtart/exercise_equipment/service/ExerciseEquipmentServiceTests.java
@@ -335,4 +335,71 @@ class ExerciseEquipmentServiceTests {
         assertEquals(2, result.size());
         verify(exerciseEquipmentRepository, times(1)).findAll();
     }
+
+    @DisplayName("운동 부위별 운동기구 조회 성공")
+    @Test
+    void testFindEquipmentByBodyPart_Success() {
+        // Given
+        String bodyPart = "testBodyPart1";
+
+        // Mock 데이터 생성
+        List<ExerciseEquipment> equipmentList = new ArrayList<>();
+        equipmentList.add(ExerciseEquipment.builder()
+                .exerciseEquipmentCode(1L)
+                .exerciseEquipmentName("testName1")
+                .bodyPart("testBodyPart1")
+                .exerciseDescription("testDescription1")
+                .exerciseImage("testImage1")
+                .recommendedVideo("testVideo1")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build());
+        equipmentList.add(ExerciseEquipment.builder()
+                .exerciseEquipmentCode(2L)
+                .exerciseEquipmentName("testName2")
+                .bodyPart("testBodyPart2")
+                .exerciseDescription("testDescription2")
+                .exerciseImage("testImage2")
+                .recommendedVideo("testVideo2")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build());
+
+        when(exerciseEquipmentRepository.findByBodyPart(bodyPart)).thenReturn(equipmentList);
+
+        when(modelMapper.map(equipmentList.get(0), ExerciseEquipmentDTO.class)).thenReturn(new ExerciseEquipmentDTO(
+                1L, "testName1", "testBodyPart1", "testDescription1", "testImage1", "testVideo1", LocalDateTime.now(), LocalDateTime.now()
+        ));
+
+        when(modelMapper.map(equipmentList.get(1), ExerciseEquipmentDTO.class)).thenReturn(new ExerciseEquipmentDTO(
+                2L, "testName2", "testBodyPart2", "testDescription2", "testImage2", "testVideo2", LocalDateTime.now(), LocalDateTime.now()
+        ));
+
+        // When
+        List<ExerciseEquipmentDTO> result = exerciseEquipmentService.findByBodyPart(bodyPart);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("testName1", result.get(0).getExerciseEquipmentName());
+        assertEquals("testName2", result.get(1).getExerciseEquipmentName());
+        verify(exerciseEquipmentRepository, times(1)).findByBodyPart(bodyPart);
+    }
+
+    @DisplayName("운동 부위별 운동기구 조회 실패 - 해당 부위에 대한 운동기구 없음")
+    @Test
+    void testFindEquipmentByBodyPart_NotFound() {
+        // Given
+        String bodyPart = "등";
+
+        when(exerciseEquipmentRepository.findByBodyPart(bodyPart)).thenReturn(new ArrayList<>());
+
+        // When & Then
+        CommonException exception = assertThrows(CommonException.class, () -> {
+            exerciseEquipmentService.findByBodyPart(bodyPart);
+        });
+
+        assertEquals(StatusEnum.EQUIPMENT_NOT_FOUND, exception.getStatusEnum());
+        verify(exerciseEquipmentRepository, times(1)).findByBodyPart(bodyPart);
+    }
 }


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
OpenAI 조회를 할 때 부위마다 추천 운동 루틴을 짤 때 사용할 수 있도록 운동기구에서의 부위 별 운동기구 조회 기능을 추가했고, 테스트 코드도 추가했습니다.