### PR TITLE
✨ 기능 추가: callOpenAI메서드 role-system추가/generatePrompt, generateRoutine메서드 추가

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/gpt/service/GptService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/gpt/service/GptService.java
@@ -1,41 +1,70 @@
 package com.dev5ops.healthtart.gpt.service;
 
 import com.dev5ops.healthtart.common.config.GptConfig;
-import com.dev5ops.healthtart.user.domain.entity.UserEntity;
+import com.dev5ops.healthtart.common.exception.CommonException;
+import com.dev5ops.healthtart.common.exception.StatusEnum;
+import com.dev5ops.healthtart.exercise_equipment.domain.dto.ExerciseEquipmentDTO;
+import com.dev5ops.healthtart.exercise_equipment.service.ExerciseEquipmentService;
+import com.dev5ops.healthtart.user.domain.dto.UserDTO;
+import com.dev5ops.healthtart.user.service.UserServiceImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class GptService {
 
-    private GptConfig gptConfig;
-    private RestTemplate restTemplate;
+    private final UserServiceImpl userServiceImpl;
+    private final ExerciseEquipmentService exerciseEquipmentService;
+    private final GptConfig gptConfig;
+    private final RestTemplate restTemplate;
 
     private static final String API_URL = "https://api.openai.com/v1/chat/completions";
 
     public String callOpenAI(String prompt, int maxTokens) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(gptConfig.getSecretKey());
-
-        Map<String, Object> requestBody = new HashMap<>();
-        requestBody.put("model", gptConfig.getModel());
-        requestBody.put("messages", new Object[] {
+        headers.setContentType(MediaType.APPLICATION_JSON); // JSON형식으로 데이터를 주고 받을 것임을 알림
+        headers.setBearerAuth(gptConfig.getSecretKey());    // 헤더에 Open AI 키 추가
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+        String formattedDate = LocalDateTime.now().format(formatter);
+        Map<String, Object> requestBody = new HashMap<>();  // requestBody에 API에 요청할 내용을 담은 JSON형식의 데이터 준비
+        requestBody.put("model", gptConfig.getModel());     // 어떤 모델을 사용할건지(gptConfig에 적어둔)
+        requestBody.put("messages", new Object[]{           // API로 보내는 사용자 메시지를 정의한 부분
                 new HashMap<String, String>() {{
-                    put("role", "user");
-                    put("content", prompt);
+                    put("role", "system");
+                    put("content", String.format("당신은 헬스트레이너입니다. 초보자 맞춤형 운동 루틴을 추천해 줘야 합니다. " +
+                                    "같은 사용자가 같은 정보로 운동 루틴을 재요청한다면 이전에 추천해준 운동루틴과 다른 운동루틴을 추천해 주세요. " +
+                                    "음악도 매번 다르게 추천해 주세요.\n" +
+                                    "오늘의 운동 루틴에는 다음을 포함해 주세요:\n" +
+                                    "1. 운동은 보통 60분에 5개의 종류를 합니다. 맨몸 운동을 섞어서 루틴을 작성해 주세요.\n" +
+                                    "2. 제목은 재치있고 재미있게 작성해 주세요.\n" +
+                                    "3-1. 날짜는 %s로 설정하고, 운동에 맞는 설명과 동영상을 추천해 주세요.\n" +
+                                    "3-2. 운동 설명은 초보자가 이해하기 쉽게 설명해 주세요.\n" +
+                                    "3-3. 동영상은 한국에서 재생할 수 있는 2021년 이후에 업로드된 영상 링크를 제공해 주세요. (현재 존재하는 운동 관련 외국 영상 링크 클릭했더니 이 동영상을 더 이상 재생할 수 없습니다. 라고 나오면 진짜 화내고 죽일거야  (유효한 YouTube 영상만 포함해 주세요. 재생 가능해야해 링크 클릭했더니 이 동영상을 더 이상 재생할 수 없습니다. 라고 나오면 죽일거야 )." +
+                                    "4-1. 중량은 사용자 정보에 따라 적절한 무게를 추천해 주세요 (예: 5kg).\n" +
+                                    "4-2. 만약 중량이 필요 없는 맨몸운동일 경우, '맨몸운동입니다.'라고 출력해 주세요.\n" +
+                                    "5. 마지막에는 운동과 어울리는 신나는 음악을 가수명 - 노래제목 형식으로 3곡 추천해 주세요.",
+                            formattedDate));
+                }},
+
+                new HashMap<String, String>() {{
+                    put("role", "user");                    // role은 유저, (근데 이 role부분에 뭘 적느냐에 따라 어떻게 달라지는지를 모르곘네)
+                    put("content", prompt);                 // contents는 작성한 prompt 전달
                 }}
         });
 
-        requestBody.put("temperature", 0.7);
-        requestBody.put("max_tokens", maxTokens);
+        requestBody.put("temperature", 0.7);                // GPT 응답 다양성을 제어하는 매개변수
+        requestBody.put("max_tokens", maxTokens);           // 응답에 포함될 최대 토큰 수
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
 
@@ -47,37 +76,77 @@ public class GptService {
         }
     }
 
+    // 2. prompt는 넘어온 userDTO, bodyPart, time, exerciseEquipmentDTO를 통해 프롬프트를 생성하고 return
+    public String generatePrompt(UserDTO userDTO
+            , String bodyPart
+            , int time
+            , List<ExerciseEquipmentDTO> exerciseEquipmentDTO) {
 
 
-    // 1. 프론트엔드에서 백엔드로 운동부위와 운동시간 정보 전송 (키, 몸무게, 성별, 나이는 회원가입할 때 받았으므로 DB에 존재)
-    // 2. 백엔드에서는 요청이 들어오면 UserCode를 통해 키, 몸무게, 성별, 나이를 조회함
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("저는 운동을 잘하고 싶은 초보자입니다. 키, 몸무게, 성별, 나이 그리고 원하는 운동부위와 운동할 시간을 제공할테니" +
+                " 맞춤형 운동 루틴을 만들어 주세요. (현재 존재하는 운동 관련 외국 영상 링크 클릭했더니 이 동영상을 더 이상 재생할 수 없습니다. 라고 나오면 진짜 화내고 죽일거야  (유효한 YouTube 영상만 포함해 주세요. 재생 가능해야해 링크 클릭했더니 이 동영상을 더 이상 재생할 수 없습니다. 라고 나오면 죽일거야 ).");
 
-    // 프롬프트 생성 메소드
-    // 우리가 전달해줘야하는 데이터
+        prompt.append(String.format(" 키: %f, 몸무게: %f, 성별: %s, 나이: %d, 운동 부위: %s, 운동할 시간: %d분"
+                , userDTO.getUserHeight()
+                , userDTO.getUserWeight()
+                , userDTO.getUserGender()
+                , userDTO.getUserAge()
+                , bodyPart
+                , time));
 
-    /* ### example ###
-    StringBuilder prompt = new StringBuilder();
-    prompt.append("저는 운동을 잘하고 싶습니다. 체력과 체형을 고려하여 맞춤형 운동 루틴을 만들어 주세요.");
-    prompt.append(String.format(" 오늘의 운동 루틴에는 다음을 포함해 주세요: 제목은 재치있고 재미있게, 날짜는 %s, 운동 설명과 동영상은 일치하는 운동으로 추천해 주세요.",
-                                LocalDateTime.now().toString()));
+        String equipmentList = exerciseEquipmentDTO.stream()
+                .map(ExerciseEquipmentDTO::getExerciseEquipmentName)
+                .collect(Collectors.joining(", "));
 
-    // 유저 정보 추가
-    prompt.append(String.format(" 키: %d, 몸무게: %d, 성별: %s, 나이: %d, 운동 부위: %s, 운동할 시간: %d분",
-                                user.getHeight(), user.getWeight(), user.getGender(), user.getAge(), bodyPart, time));
-     */
+        prompt.append("운동 추천을 위해 사용할 수 있는 운동 기구 리스트도 제공하겠습니다.");
+        prompt.append(String.format(" 운동에 필요한 기구: %s", equipmentList));
+        System.out.println(equipmentList);
 
-    // 나짱이가 보내줬던 형식으로 생성하도록
+        prompt.append("아래에 제공된 형식을 사용해 주세요.");
+        prompt.append("**운동 루틴**\n" +
+                "제목: {운동 목적에 맞는 제목}\n" +
+                "날짜: {현재 날짜}\n" +
+                "운동 부위: {사용자가 선택한 운동 부위}\n" +
+                "키: {사용자 키}\n" +
+                "몸무게: {사용자 몸무게}\n" +
+                "성별: {사용자 성별}\n" +
+                "나이: {사용자 나이}\n" +
+                "운동 시간: {사용자가 입력한 운동 시간}\n" +
+                "\n" +
+                "오늘의 운동 루틴을 추천해 드립니다:\n" +
+                "\n" +
+                "n. {운동 명}\n" +
+                "   - 세트 및 반복: {사용자정보에 따른 세트 및 반복 횟수}\n" +
+                "   - 운동 설명: {운동 설명}\n" +
+                "   - 중량: {사용자 정보에 따른 적절한 중량}\n" +
+                "   - 추천 영상: {운동 관련 영상 링크}\n (현재 존재하는 운동 관련 외국 영상 링크 클릭했더니 이 동영상을 더 이상 재생할 수 없습니다. 라고 나오면 진짜 화내고 죽일거야  (유효한 YouTube 영상만 포함해 주세요. 재생 가능해야해 링크 클릭했더니 이 동영상을 더 이상 재생할 수 없습니다. 라고 나오면 죽일거야 )." +
+                "\n" +
+                "추천 MusicList:\n" +
+                "- 1. {가수명 - 노래제목} \n" +
+                "- 2. {가수명 - 노래제목} \n" +
+                "- 3. {가수명 - 노래제목} \n");
 
-    public String generateRoutine
-            (UserEntity userCode, String bodyPart, int time) {
-        // 유저코드를 통해 유저에서 유저의 키, 나이, 성별, 몸무게를 가져온다.
-        // if 헬스장을 등록한 회원이라면 equipmentPerGymService에서 헬스장별 운동부위별 운동기구 이름 조회
-        // else exerciseEquipmentService에서 운동부위별 운동기구 이름 조회
-        // generatePrompt 메서드에 파라미터값으로 userCode, equipmentPerBodyPart ,bodyPart, time 전달하고 리턴값을 callOpenAI에 전달
-        return null;
+        return prompt.toString();
     }
 
-    // 3. 프론트에서는 받아온 운동 루틴의 세트수, 반복 횟수를 수정할 수 있고 하고싶지 않은 운동은 제외 하고 저장(DB에 저장하는 개념이 아님)하고, 시작을 누르면 DB에 저장을 위해 백엔드로 요청(JSON형식)
-    // 4. 백엔드에서는 수정된 루틴을 저장할 수 있음
+    // 1. 로그인한 회원이 운동부위와 시간을 선택하면 루틴생성을 위해 userCode, bodyPart를 사용해 유저정보와 운동기구정보를 prompt로 보냄
+    // 3. 리턴 값은 String prompt에 저장되어 callOpenAPI에 넘겨지고 루틴 생성됨
+    public String generateRoutine(String userCode, String bodyPart, int time) {
+        UserDTO userDTO = userServiceImpl.findById(userCode);
+        List<ExerciseEquipmentDTO> exerciseEquipmentDTO = exerciseEquipmentService.findByBodyPart(bodyPart);
+
+        String prompt = generatePrompt(userDTO, bodyPart, time, exerciseEquipmentDTO);
+
+        try {
+            return callOpenAI(prompt, 3000);
+        } catch (JsonProcessingException e) {
+            throw new CommonException(StatusEnum.INTERNAL_SERVER_ERROR);
+        }
+    }
 }
+
+// 3. 프론트에서는 받아온 운동 루틴의 세트수, 반복 횟수를 수정할 수 있고 하고싶지 않은 운동은 제외 하고 저장(DB에 저장하는 개념이 아님)하고, 시작을 누르면 DB에 저장을 위해 백엔드로 요청(JSON형식)
+// 4. 백엔드에서는 수정된 루틴을 저장할 수 있음
+
 

--- a/healthtart/src/main/java/com/dev5ops/healthtart/recommended_workout_history/domain/dto/RecommendedWorkoutHistoryDTO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/recommended_workout_history/domain/dto/RecommendedWorkoutHistoryDTO.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.recommended_workout_history.dto;
+package com.dev5ops.healthtart.recommended_workout_history.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/recommended_workout_history/domain/entity/RecommendedWorkoutHistory.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/recommended_workout_history/domain/entity/RecommendedWorkoutHistory.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.recommended_workout_history.aggregate;
+package com.dev5ops.healthtart.recommended_workout_history.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/controller/RecordPerUserController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/controller/RecordPerUserController.java
@@ -1,7 +1,8 @@
 package com.dev5ops.healthtart.record_per_user.controller;
 
-import com.dev5ops.healthtart.record_per_user.aggregate.vo.response.ResponseFindPerUserVO;
-import com.dev5ops.healthtart.record_per_user.dto.RecordPerUserDTO;
+
+import com.dev5ops.healthtart.record_per_user.domain.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.domain.vo.vo.response.ResponseFindPerUserVO;
 import com.dev5ops.healthtart.record_per_user.service.RecordPerUserService;
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import io.swagger.v3.oas.annotations.Operation;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/dto/RecordPerUserDTO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/dto/RecordPerUserDTO.java
@@ -1,8 +1,11 @@
-package com.dev5ops.healthtart.record_per_user.dto;
+package com.dev5ops.healthtart.record_per_user.domain.dto;
 
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/entity/RecordPerUser.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/entity/RecordPerUser.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.record_per_user.aggregate;
+package com.dev5ops.healthtart.record_per_user.domain.entity;
 
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import jakarta.persistence.*;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/request/RequestRegisterRecordPerUserVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/request/RequestRegisterRecordPerUserVO.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.record_per_user.aggregate.vo.request;
+package com.dev5ops.healthtart.record_per_user.domain.vo.vo.request;
 
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import lombok.AllArgsConstructor;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/response/ResponseFindPerUserVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/response/ResponseFindPerUserVO.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.record_per_user.aggregate.vo.response;
+package com.dev5ops.healthtart.record_per_user.domain.vo.vo.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/response/ResponseRecordPerUserVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/response/ResponseRecordPerUserVO.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.record_per_user.aggregate.vo.response;
+package com.dev5ops.healthtart.record_per_user.domain.vo.vo.response;
 
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import lombok.AllArgsConstructor;
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class ResponseRegisterRecordPerUserVO {
+public class ResponseRecordPerUserVO {
     private Long userRecordCode;
     private LocalDate dayOfExercise;
     private LocalTime exerciseDuration;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/response/ResponseRegisterRecordPerUserVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/domain/vo/vo/response/ResponseRegisterRecordPerUserVO.java
@@ -1,4 +1,4 @@
-package com.dev5ops.healthtart.record_per_user.aggregate.vo.response;
+package com.dev5ops.healthtart.record_per_user.domain.vo.vo.response;
 
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import lombok.AllArgsConstructor;
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class ResponseRecordPerUserVO {
+public class ResponseRegisterRecordPerUserVO {
     private Long userRecordCode;
     private LocalDate dayOfExercise;
     private LocalTime exerciseDuration;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/repository/RecordPerUserRepository.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/repository/RecordPerUserRepository.java
@@ -1,6 +1,6 @@
 package com.dev5ops.healthtart.record_per_user.repository;
 
-import com.dev5ops.healthtart.record_per_user.aggregate.RecordPerUser;
+import com.dev5ops.healthtart.record_per_user.domain.entity.RecordPerUser;
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserService.java
@@ -2,9 +2,9 @@ package com.dev5ops.healthtart.record_per_user.service;
 
 import com.dev5ops.healthtart.common.exception.CommonException;
 import com.dev5ops.healthtart.common.exception.StatusEnum;
-import com.dev5ops.healthtart.record_per_user.aggregate.RecordPerUser;
-import com.dev5ops.healthtart.record_per_user.aggregate.vo.request.RequestRegisterRecordPerUserVO;
-import com.dev5ops.healthtart.record_per_user.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.domain.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.domain.entity.RecordPerUser;
+import com.dev5ops.healthtart.record_per_user.domain.vo.vo.request.RequestRegisterRecordPerUserVO;
 import com.dev5ops.healthtart.record_per_user.repository.RecordPerUserRepository;
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
@@ -61,18 +61,6 @@ public class RecordPerUserService {
         return modelMapper.map(recordPerUser, RecordPerUserDTO.class);
     }
 
-    // 운동 기록을 수정할 일이 없는거 같음
-//    public RecordPerUserDTO editRecordPerUser(Long userRecordCode, RequestEditRecordPerUserVO request){
-//        RecordPerUser recordPerUser = recordPerUserRepository
-//                .findById(userRecordCode).orElseThrow(() -> new CommonException(StatusEnum.RECORD_NOT_FOUND));
-//
-//        recordPerUser.setExerciseDuration(request.getExerciseDuration());
-//        recordPerUser.setUpdatedAt(request.getUpdatedAt());
-//
-//        recordPerUser = recordPerUserRepository.save(recordPerUser);
-//
-//        return modelMapper.map(recordPerUser, RecordPerUserDTO.class);
-//    }
 
     public void deleteRecordPerUser(Long userRecordCode) {
         RecordPerUser recordPerUser = recordPerUserRepository
@@ -80,7 +68,5 @@ public class RecordPerUserService {
 
         recordPerUserRepository.delete(recordPerUser);
     }
-
-
 
 }

--- a/healthtart/src/test/java/com/dev5ops/healthtart/gpt/service/GptServiceTests.java
+++ b/healthtart/src/test/java/com/dev5ops/healthtart/gpt/service/GptServiceTests.java
@@ -1,0 +1,34 @@
+package com.dev5ops.healthtart.gpt.service;
+
+import com.dev5ops.healthtart.user.domain.dto.UserDTO;
+import com.dev5ops.healthtart.user.service.UserService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class GptServiceTests {
+
+    @Autowired
+    private GptService gptService;
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    public void testCallOpenAI() throws JsonProcessingException {
+        String userCode = "20241007-05bfb06b-8eda-4857-8681-40d1eccb829d";
+        UserDTO user = userService.findById(userCode);
+        System.out.println("유저 정보 = " + user.getUserName());
+
+        String bodyPart = "하체";
+        int workoutTime = 90;
+        String response = gptService.generateRoutine(userCode, bodyPart, workoutTime);
+        System.out.println("GPT 응답 = " + response);
+        assertNotNull(response);
+    }
+
+}

--- a/healthtart/src/test/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserServiceTests.java
+++ b/healthtart/src/test/java/com/dev5ops/healthtart/record_per_user/service/RecordPerUserServiceTests.java
@@ -1,8 +1,7 @@
 package com.dev5ops.healthtart.record_per_user.service;
 
-
-import com.dev5ops.healthtart.record_per_user.aggregate.RecordPerUser;
-import com.dev5ops.healthtart.record_per_user.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.domain.dto.RecordPerUserDTO;
+import com.dev5ops.healthtart.record_per_user.domain.entity.RecordPerUser;
 import com.dev5ops.healthtart.record_per_user.repository.RecordPerUserRepository;
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
- 제목 : feat(72): callOpenAI메서드 role-system추가/generatePrompt, generateRoutine메서드 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- callOpenAI메서드
첫 번째 메시지에서 role을 "system"으로 설정하고, 헬스트레이너 역할에 대한 설명을 추가했습니다. 이렇게 하면 GPT는 이 역할에 맞게 응답을 생성합니다.
두 번째 메시지에서 role을 "user"로 설정하고, 사용자가 제공하는 프롬프트를 전달합니다.
- generatePrompt메서드
userCode를 통해 키, 몸무게, 성별, 나이를, 입력을통해 운동부위와 운동할 시간을 받아 gpt에 전달할 프롬프트를 작성합니다.
- generateRoutine메서드
generatePrompt의 리턴값을 이용해 callOpenAI를 호출해 루틴을 생성합니다. maxToken은 3000으로 설정했습니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/bfa1e7b9-d15d-49ea-bed0-6c9ec5520b44)

<br/>

## 🔧 앞으로의 과제

- 운동 순서 번호, 세트 수, 개수, 운동 세트 당 무게, 운동 시간, 등록 시간, 수정시간, 운동루틴번호, 운동기구번호를 운동루틴별 운동에 저장 
- 운동루틴번호, 제목, 운동할시간, 노래추천, 등록시간,수정시간을 운동루틴에 저장


  <br/>
