### PR TITLE
feat(#74): 일반 유저, OAuth2 유저 로그인, 회원가입 기능 수정

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/JwtFilter.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/JwtFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -29,55 +30,46 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         log.info("UsernamePasswordAuthenticationFilter보다 먼저 동작하는 필터");
-        String token = extractToken(request);
-//        String authorizationHeader = request.getHeader("Authorization");
-//        log.info("Authorization header: {}", authorizationHeader);
-        log.info("jwt token값은 : {}", token);
-//        /* 설명. JWT 토큰이 Request Header에 있는 경우(로그인 이후 요청일 경우) */
-//        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-//            String token = authorizationHeader.substring(7);    // "Bearer "를 제외한 뒤에 토큰 부분만 추출
-//            log.info("토큰 값: " + token);
-//            if(jwtUtil.validateToken(token)) {
-//                Authentication authentication = jwtUtil.getAuthentication(token);
-//                log.info("JwtFilter를 통과한 유효한 토큰을 통해 security가 관리할 principal 객체: {}", authentication);
-//                SecurityContextHolder.getContext().setAuthentication(authentication);   // 인증이 완료되었고 이후 필터 건너뜀
-//            }else {
-//                log.warn("Invalid token received");
-//            }
-//        }else {
-//            log.info("No Bearer token found in the request");
+
+        // oauth 로그인의 경우 filter가 아닌 oauth2handler에 가기 때문에 따로 처리할 필요가 없음. 이후 요청은 jwt token을 가지고 접근할테니 따로 처리 필요없음.
+//        // SecurityContext에 이미 OAuth2 인증 정보가 있는지 확인 (OAuth2 로그인 처리)
+//        Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
+//
+//        // OAuth2 로그인의 경우 JWT 필터 통과 없이 필터 체인 계속 진행
+//        if (currentAuthentication != null && currentAuthentication instanceof OAuth2AuthenticationToken) {
+//            log.info("OAuth2 authentication detected, skipping JWT processing.");
+//            filterChain.doFilter(request, response);
+//            return;
 //        }
 
-        if (token != null) {
-            log.info("Found token: {}", token);
-            if (jwtUtil.validateToken(token)) {
-                Authentication authentication = jwtUtil.getAuthentication(token);
-                log.info("Valid token. Setting authentication: {}", authentication);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } else {
-                log.warn("Invalid token received");
-            }
+        // Authorization 헤더에서 JWT 토큰 추출
+        String authorizationHeader = request.getHeader("Authorization");
+        log.info("jwtFilter의 getHeader('Authorization'): {}", authorizationHeader);
+
+        String token = null;
+
+        // Authorization 헤더에 토큰이 있는지 확인하고, 없으면 쿼리 파라미터에서 token 값을 찾음
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            token = authorizationHeader.substring(7); // "Bearer " 이후의 토큰 값만 추출
+            log.info("Bearer 토큰 추출 완료: {}", token);
         } else {
-            log.info("No token found in the request");
+            // 헤더에 토큰이 없으면 쿼리 파라미터에서 token 값을 찾음
+            token = request.getParameter("token");
+            log.info("OAuth 로그인: 쿼리 파라미터에서 토큰 추출. 토큰 : {}", token);
         }
+
+        /* 설명. 토큰이 있을 경우에만 유효성 검사 및 인증 처리 -> 아니면 다음 필터로 넘어가게함. (oauth 유저의 경우 바로 로그인이 되기 때문에*/
+        if (token != null && jwtUtil.validateToken(token)) {
+            Authentication authentication = jwtUtil.getAuthentication(token);
+            log.info("JwtFilter를 통과한 유효한 토큰을 통해 security가 관리할 principal 객체: {}", authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);   // 인증 완료
+        } else {
+            log.warn("유효하지 않은 토큰이거나 토큰이 없습니다.");
+        }
+
 
         /* 설명. 위의 if문으로 인증된 Authentication 객체가 principal 객체로 관리되지 않는다면 다음 필터 실행 */
         filterChain.doFilter(request, response);    // 실행 될 다음 필터는 UsernamePasswordAuthenticationFilter
     }
 
-    private String extractToken(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader("Authorization");
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            return authorizationHeader.substring(7);
-        }
-
-        // URL 파라미터에서 토큰 추출
-        String tokenParam = request.getParameter("token");
-        log.info("extractToken의 tokenParam: {}", tokenParam);
-        if (tokenParam != null && !tokenParam.isEmpty()) {
-            return tokenParam;
-        }
-
-        return null;
-    }
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/OAuth2AuthenticationSuccessHandler.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/OAuth2AuthenticationSuccessHandler.java
@@ -4,6 +4,7 @@ import com.dev5ops.healthtart.security.JwtUtil;
 import com.dev5ops.healthtart.user.domain.dto.JwtTokenDTO;
 import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import jakarta.servlet.ServletException;
@@ -66,6 +67,20 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         // 응답 헤더에 토큰 추가
         response.addHeader("Authorization", "Bearer " + token);
+
+
+        // websecurity에서 oauth2 로그인 설정 추가 부분에서 해주기 때문에 따로 구현할 필요가 없음.
+//        // **Authentication 객체 생성 및 설정**
+//        OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(
+//                oAuth2User,
+//                oAuth2User.getAuthorities(),
+//                ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()
+//        );
+//
+//        // **SecurityContext에 Authentication 객체 저장**
+//        SecurityContextHolder.getContext().setAuthentication(oAuth2AuthenticationToken);
+
+
 
         String redirectUrl = String.format("/users/login/%s", provider.toLowerCase());
         redirectUrl = redirectUrl + "?token=" + token;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dev5ops.healthtart.user.controller;
 
+import com.dev5ops.healthtart.user.domain.CustomUserDetails;
 import com.dev5ops.healthtart.user.domain.dto.UserDTO;
 import com.dev5ops.healthtart.security.JwtUtil;
 import com.dev5ops.healthtart.user.domain.vo.request.RequestInsertUserVO;
@@ -37,10 +38,10 @@ public class UserController {
         this.userService = userService;
     }
 
-    @PostMapping("/signUp")
+    @PostMapping("/signup")
     public ResponseEntity<ResponseInsertUserVO> insertUser(@RequestBody RequestInsertUserVO request) {
         ResponseInsertUserVO responseUser = userService.signUpUser(request);
-
+        log.info("여기 오긴 왔나요??");
         return ResponseEntity.status(HttpStatus.CREATED).body(responseUser);
     }
 
@@ -55,11 +56,10 @@ public class UserController {
             if (!jwtUtil.validateToken(token)) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
             }
-            log.info("아ㅣ십ㄹ");
             // 토큰에서 이메일 추출
             String email = jwtUtil.getEmailFromToken(token);
             String userCode = jwtUtil.getUserCodeFromToken(token);
-            log.info("handle google controller email: {}", userCode);
+            log.info("handle google controller code: {}", userCode);
 
 //            log.info("구글로 로그인 했을때에는 말이야?: {}", authentication.getPrincipal());
             // 사용자 정보 조회
@@ -90,18 +90,21 @@ public class UserController {
 //    public ResponseEntity<?> handleGoogleLogin(@RequestHeader("Authorization") String authHeader) {
     public ResponseEntity<?> handleKakaoLogin(@RequestParam String token, Authentication authentication) {
         try {
+//            log.info("authentication이 없어서 오류?? : {}", authentication.getPrincipal());
+            log.info("authentication 자체가 널인가??: {}", authentication);
             // "Bearer " 접두사 제거
 //            String token = authHeader.substring(7);
 
-            // 토큰 유효성 검사
-            if (!jwtUtil.validateToken(token)) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
-            }
+            // 토큰 유효성 검사 -> 유효성검사가 필요없음. -> 이미 jwtfilter를 거쳐서 나오기 때문
+//            if (!jwtUtil.validateToken(token)) {
+//                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
+//            }
+            log.info("jwt 토큰 값은: {} ", token);
             // 토큰에서 이메일 추출
 //            String email = jwtUtil.getEmailFromToken(token);
             String userCode = jwtUtil.getUserCodeFromToken(token);
-            log.info("handle google controller email: {}", userCode);
-            log.info("카카오로 로그인 했을때에는 말이야?: {}", authentication.getPrincipal());
+            log.info("handle kakao controller code: {}", userCode);
+//            log.info("카카오로 로그인 했을때에는 말이야?: {}", authentication.getPrincipal());
 
             // 사용자 정보 조회
             UserDTO userDTO = userService.findById(userCode);
@@ -127,15 +130,16 @@ public class UserController {
         }
     }
 
-
-
-
     @GetMapping("/mypage")
     public ResponseEntity<?> getMyPage(Authentication authentication) {
         log.info("Mypage request received");
-
+        log.info("mypage 시에 모든 authentication 정보 보기: {}", authentication.toString());
             log.info(authentication.toString());
-            String userCode = authentication.getName();
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String userCode = userDetails.getUserDTO().getUserCode();  // CustomUserDetails에서 UserDTO로 접근하여 userCode 가져옴
+        log.info("userDetails: {}", userDetails.getUserDTO().toString());
+        log.info("userCode: {}", userCode);
 //            String userEmail = jwtUtil.getEmailFromToken(authentication.getName());
 //            log.info("Fetching mypage for user: {}", userEmail);
 

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/CustomUserDetails.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package com.dev5ops.healthtart.user.domain;
+
+import com.dev5ops.healthtart.user.domain.dto.UserDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+
+// security의 loadUserByUsername의 리턴 값을 바꿔주기 위한(토큰 생성을 위해) 커스텀 user
+@Getter
+@Setter
+@AllArgsConstructor
+@ToString
+public class CustomUserDetails implements UserDetails {
+
+    private UserDTO userDTO;  // UserDTO를 담는 필드
+    private List<GrantedAuthority> authorities;  // 권한 정보를 담을 필드
+
+    // 추가 필드: true/false 값을 받을 필드
+    private boolean isAccountNonExpired;
+    private boolean isAccountNonLocked;
+    private boolean isCredentialsNonExpired;
+    private boolean isEnabled;
+
+    @Override
+    public String getUsername() {
+        return userDTO.getUserEmail();  // 실제 유저 이메일을 반환
+    }
+
+    @Override
+    public String getPassword() {
+        return userDTO.getUserPassword();  // 실제 비밀번호를 반환하도록 수정
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return this.isAccountNonExpired;  // 사용자로부터 받은 값을 반환
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return this.isAccountNonLocked;  // 사용자로부터 받은 값을 반환
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return this.isCredentialsNonExpired;  // 사용자로부터 받은 값을 반환
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.isEnabled;  // 사용자로부터 받은 값을 반환
+    }
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/dto/UserDTO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/dto/UserDTO.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@ToString
 public class UserDTO {
 
     private String userCode;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/service/CustomOAuth2UserService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/service/CustomOAuth2UserService.java
@@ -98,6 +98,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }*/
 
         user = userRepository.save(user);
+        // 여기 위에까지가 회원가입 하는것.(또는 수정)
+
+
         log.info("customService user : {} ", user.toString());
         // User 정보를 포함한 attributes 맵 생성
         Map<String, Object> userAttributes = new HashMap<>(attributes);


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
먼저 CustomUserDetails을 만들어 Authentication 생성시에 더 많은 데이터를 가지고 있게 했습니다.
CustomUserDetails는 UserDTO를 가지고 있지만 아직 모든 부분에 데이터를 추가한게 아닙니다.(ex: role에 대한 부분은 없음)
따라서 추후 수정될 수도 있습니다.
사용 방법은 
        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
        String userCode = userDetails.getUserDTO().getUserCode();  
이런식으로 사용이 가능합니다. 손쉽게 현재 유저의 userCode를 가져올 수 있습니다!!

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/ed067af3-0c18-47e2-96d5-5bcb3c856d56)
![image](https://github.com/user-attachments/assets/69d522b8-f3fe-4721-988b-75cdb3215a24)

<br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
프론트와 연동시 User 로직 수정해야함.
관리자가 회원 전체 조회하는거
라이벌 만들기 -> 라이벌 선택하는거 만들기 -> 전체 조회하는거 -> 필터거쳐서 찾아와야함.(필터는 생각)
마이페지이 만들기 (전달할 데이터 생각하기)
회원 업데이트 -> 회우너 삭제하는 로직(flag = false)
라이벌 등록하는것. -> 필요한 데이터들?
내가 등록한 라이벌의 데이터 가져오는것. -> 다른 유저기 때문에 비밀번호 같은거 안가져오게 조심.
내 정보도 6번이랑 같이 해야함. -> 그냥 6, 7번 해가지고 내정보 다른사람 정보 비교하는것
  <br/>

close #74 