### PR TITLE
feat(#58) OAuth2 유저 프론트 회원가입, 로그인 연동 성공

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/AuthenticationFilter.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/AuthenticationFilter.java
@@ -94,6 +94,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
         List<String> roles = authResult.getAuthorities().stream()
                 .map(role -> role.getAuthority())
                 .collect(Collectors.toList());
+        log.info("roles: {}", roles.toString());
 
         JwtTokenDTO tokenDTO = new JwtTokenDTO(userCode, userEmail, userNickname); // principal에서 제공해주는 데이터가 적음.
         String token = jwtUtil.generateToken(tokenDTO, roles, null);

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/OAuth2AuthenticationSuccessHandler.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/OAuth2AuthenticationSuccessHandler.java
@@ -16,6 +16,8 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Component
@@ -47,7 +49,10 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String userCode = user.getUserCode();
         String userEmail = user.getUserEmail();
         String userNickname = user.getUserNickname();
+
         String userName = user.getUserName();
+        String encodedUserName = URLEncoder.encode(userName, StandardCharsets.UTF_8);
+
         String provider = user.getProvider();
         String providerId = user.getProviderId();
 
@@ -68,7 +73,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         if(userNickname != null){ // 이미 회원가입된 회원
             redirectUrl += "token?=" + token;
         }else{ // 신규 가입회원 -> 추가정보 페이지로 리다이렉트
-            redirectUrl += "/addinfo" + "?token=" + token + "&userName=" + userName + "&userEmail=" + userEmail + "&provider=" + provider + "&providerId=" + providerId;
+                                                            // userName은 한글이어서 UTF-8로 인코딩
+            redirectUrl += "/addinfo" + "?token=" + token + "&userName=" + encodedUserName + "&userEmail=" + userEmail + "&provider=" + provider + "&providerId=" + providerId;
         }
 
         log.info("Redirecting to: {}", redirectUrl);

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/OAuth2AuthenticationSuccessHandler.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/OAuth2AuthenticationSuccessHandler.java
@@ -48,18 +48,18 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         String userCode = user.getUserCode();
         String userEmail = user.getUserEmail();
-        String userName = user.getUserName();
+        String userNickname = user.getUserNickname();
 
         log.info("userCode: {}", userCode);
         log.info("userEmail: {}", userEmail);
-        log.info("userName: {}", userName);
+        log.info("userNickname: {}", userNickname);
         log.info("provider: {}", provider);
 
         // 사용자 권한 설정 (예: "ROLE_USER")
         List<String> roles = List.of("ROLE_MEMBER");
 
         // JWT 토큰에 들어갈 데이터(JwtTokenDTO)
-        JwtTokenDTO tokenDTO = new JwtTokenDTO(userCode, userEmail, userName);
+        JwtTokenDTO tokenDTO = new JwtTokenDTO(userCode, userEmail, userNickname);
 
         // JWT 토큰 생성
         String token = jwtUtil.generateToken(tokenDTO, roles, provider);
@@ -68,21 +68,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         // 응답 헤더에 토큰 추가
         response.addHeader("Authorization", "Bearer " + token);
 
-
-        // websecurity에서 oauth2 로그인 설정 추가 부분에서 해주기 때문에 따로 구현할 필요가 없음.
-//        // **Authentication 객체 생성 및 설정**
-//        OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(
-//                oAuth2User,
-//                oAuth2User.getAuthorities(),
-//                ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()
-//        );
-//
-//        // **SecurityContext에 Authentication 객체 저장**
-//        SecurityContextHolder.getContext().setAuthentication(oAuth2AuthenticationToken);
-
-
-
-        String redirectUrl = String.format("/users/login/%s", provider.toLowerCase());
+        String redirectUrl = String.format("http://localhost:5173");
+//        String redirectUrl = String.format("http://localhost:5173/add-info/%s", provider.toLowerCase());
+//        String redirectUrl = String.format("/users/login/%s", provider.toLowerCase());
         redirectUrl = redirectUrl + "?token=" + token;
         log.info("Redirecting to: {}", redirectUrl);
 
@@ -96,4 +84,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         }
         return "unknown";
     }
+
+
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/WebSecurity.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/WebSecurity.java
@@ -81,18 +81,18 @@ public class WebSecurity {
                 /* UserDetails를 상속받는 Service 계층 + BCrypt 암호화 */
                 .authenticationManager(authenticationManager)
 
-//                /* OAuth2 로그인 설정 추가 */
-//                .oauth2Login(oauth2 -> oauth2
-//                        .authorizationEndpoint(authorization -> authorization
-//                                .baseUri("/oauth2/authorization"))
-//                        .redirectionEndpoint(redirection -> redirection
-//                                .baseUri("/login/oauth2/code/*"))
-//                        .userInfoEndpoint(userInfo -> userInfo
-//                                .userService(customOAuth2UserService)
-//                        )
-//                        .successHandler(new OAuth2AuthenticationSuccessHandler(jwtUtil))
-////                        .failureHandler(new OAuth2AuthenticationFailureHandler())
-//                )
+                /* OAuth2 로그인 설정 추가 */
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/oauth2/authorization"))
+                        .redirectionEndpoint(redirection -> redirection
+                                .baseUri("/login/oauth2/code/*"))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .successHandler(new OAuth2AuthenticationSuccessHandler(jwtUtil))
+//                        .failureHandler(new OAuth2AuthenticationFailureHandler())
+                )
 
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         // JWT 인증 필터 추가

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/WebSecurity.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/WebSecurity.java
@@ -63,6 +63,8 @@ public class WebSecurity {
                         authz
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "POST")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "OPTIONS")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/users/nickname/check", "GET")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/users/oauth2", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "PATCH")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/login/**", "OPTIONS")).permitAll()

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.dev5ops.healthtart.user.domain.CustomUserDetails;
 import com.dev5ops.healthtart.user.domain.dto.UserDTO;
 import com.dev5ops.healthtart.security.JwtUtil;
 import com.dev5ops.healthtart.user.domain.vo.request.RequestInsertUserVO;
+import com.dev5ops.healthtart.user.domain.vo.request.RequestOauth2VO;
 import com.dev5ops.healthtart.user.domain.vo.response.ResponseFindUserVO;
 import com.dev5ops.healthtart.user.domain.vo.response.ResponseInsertUserVO;
 import com.dev5ops.healthtart.user.service.UserService;
@@ -211,5 +212,29 @@ public class UserController {
     }
 
 
+    @GetMapping("/nickname/check") // users/nickname/check
+    public ResponseEntity<Map<String, Boolean>> checkDuplicateNickname(String userNickname){
+
+        Boolean isDuplicate = userService.checkDuplicateNickname(userNickname);
+
+        // JSON 형태로 반환할 Map 생성
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("isDuplicate", isDuplicate);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response); // true이면 사용 불가
+    }
+
+    // 여기서 회원가입 시킬 예정
+    @PostMapping("/oauth2")
+    public ResponseEntity<String> saveOauth2User(@RequestBody RequestOauth2VO requestOauth2VO){
+
+        // userCode는 여기서 생성해서 저장하자.
+        // member type도 여기서
+        // flag도 여기서
+
+        userService.saveOauth2User(requestOauth2VO);
+
+        return ResponseEntity.status(HttpStatus.OK).body("잘 저장했습니다");
+    }
 
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/entity/UserEntity.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/entity/UserEntity.java
@@ -32,13 +32,13 @@ public class UserEntity {
     @Column(name = "user_password")
     private String userPassword;
 
-    @Column(name = "user_phone", nullable = false)
+    @Column(name = "user_phone")
     private String userPhone;
 
-    @Column(name = "user_nickname", nullable = false)
+    @Column(name = "user_nickname")
     private String userNickname;
 
-    @Column(name = "user_address", nullable = false)
+    @Column(name = "user_address")
     private String userAddress;
 
     @Column(name = "user_flag", nullable = false)

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/vo/request/RequestOauth2VO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/vo/request/RequestOauth2VO.java
@@ -1,0 +1,29 @@
+package com.dev5ops.healthtart.user.domain.vo.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestOauth2VO {
+
+    String userName;
+//    String userType;
+    String userEmail;
+//    String userPassword;
+    String userPhone;
+    String userNickname;
+    String userAddress;
+    // Boolean userFlag;
+    String userGender;
+    Double userHeight;
+    Double userWeight;
+    Integer userAge;
+//    LocalDateTime createdAt;
+//    LocalDateTime updatedAt;
+    String provider;
+    String providerId;
+    // Integer gymCode;
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/repository/UserRepository.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity, String> {
     UserEntity findByUserEmail(String userEmail);
 
     UserEntity findByProviderAndProviderId(String provider, String providerId);
+
+    UserEntity findByUserNickname(String userNickname);
 }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/service/UserService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/service/UserService.java
@@ -1,8 +1,8 @@
 package com.dev5ops.healthtart.user.service;
 
 import com.dev5ops.healthtart.user.domain.dto.UserDTO;
-import com.dev5ops.healthtart.user.domain.entity.UserEntity;
 import com.dev5ops.healthtart.user.domain.vo.request.RequestInsertUserVO;
+import com.dev5ops.healthtart.user.domain.vo.request.RequestOauth2VO;
 import com.dev5ops.healthtart.user.domain.vo.response.ResponseInsertUserVO;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
@@ -20,4 +20,8 @@ public interface UserService extends UserDetailsService {
     UserDTO findById(String userCode);
 
     void deleteUser(String userCode);
+
+    Boolean checkDuplicateNickname(String userNickname);
+
+    void saveOauth2User(RequestOauth2VO requestOauth2VO);
 }


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [x] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
일단 OAuth2 유저를 최초 로그인과 아닌 경우를 구분했습니다.
어떠한 유저든 OAuth2에서 제공해주는 정보가 수정되었을 수 있으므로(ex: userName(자바오)) 어떠한 유저든 로그인 시에 userRepository에서 save를 해줍니다.
최초 로그인시에는 userNickname이 null이 들어가게 되어서 이것을 통해 프론트의 어떠한 곳으로  리다이렉트를 할지 구분했습니다. 
둘 다 token값을 넘기기 위해서 로그인시 save를 했고 최초 로그인 하는 경우 추가정보 외에 제공해준 값들을 넘겨주기 위해 쿼리파라미터로 4개의 정보를 추가로 넘겨주었습니다.
이때 userName이 한글일 가능성이 있어 자바의 URLEncoder를 통해 URF-8로 인코딩 하여 경로 설정을 해주었습니다. 

  <br/>

## 이미지 첨부
- OAuth2 유저 최초 로그인시 회원가입
![image](https://github.com/user-attachments/assets/6b9f58ad-7c81-4847-b694-e9c452ad3b85)

- OAuth2 유저 최초 구분
![image](https://github.com/user-attachments/assets/1b3703c7-317e-4c0f-845c-662302e6fdea)


<br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
이번에는 백엔드로 OAuth2 유저의 redirect url을 설정했는데 프론트로 설정하여 해보고 싶습니다. 쿼리파라미터로 token을 넘기는게 보안에 어떠한 영향을 미칠까도 추가로 공부해봐야할것 같습니다.
프론트와의 연동이 아직 남았습니다. 프론트로 막힘없이 이동을 되지만 아직 프론트에서 데이터를 가져다 쓰지는 않아서 빨리 해봐야할것 같습니다.
유저 테스트가 아직 없습니다. 유저 테스트도 빨리 해야겠습니다.
현재 WebSecurity에 권한 설정이 안되어있는데 이것도 빨리 해야겠습니다.

  <br/>

#58 
