### PR TITLE
♻️ 코드 수정: WorkoutPerRoutineController, Service, ServiceImpl 타입 변경

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/controller/WorkoutPerRoutineController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/controller/WorkoutPerRoutineController.java
@@ -42,10 +42,10 @@ public class WorkoutPerRoutineController {
     }
 
     @Operation(summary = "루틴코드별 운동 단일 조회")
-    @GetMapping("/{RoutineCode}")
-    public ResponseEntity<ResponseFindWorkoutPerRoutineVO> getWorkoutPerRoutineByRoutineCode(@PathVariable Long routineCode) {
-        ResponseFindWorkoutPerRoutineVO routine = workoutPerRoutineService.findWorkoutPerRoutineByCode(routineCode);
-        return new ResponseEntity<>(routine, HttpStatus.OK);
+    @GetMapping("/detail/{routineCode}")
+    public ResponseEntity<List<ResponseFindWorkoutPerRoutineVO>> getWorkoutPerRoutineByRoutineCode(@PathVariable Long routineCode) {
+        List<ResponseFindWorkoutPerRoutineVO> routines = workoutPerRoutineService.findWorkoutPerRoutineByRoutineCode(routineCode);
+        return new ResponseEntity<>(routines, HttpStatus.OK);
     }
 
     @Operation(summary = "운동 루틴별 운동 등록")

--- a/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/domain/vo/response/ResponseFindWorkoutPerRoutineVO.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/domain/vo/response/ResponseFindWorkoutPerRoutineVO.java
@@ -5,12 +5,14 @@ import com.dev5ops.healthtart.routine.domain.entity.Routine;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class ResponseFindWorkoutPerRoutineVO {
     private Long workoutPerRoutineCode;
     private int workoutOrder;

--- a/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/service/WorkoutPerRoutineService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/service/WorkoutPerRoutineService.java
@@ -17,7 +17,7 @@ public interface WorkoutPerRoutineService {
     ResponseFindWorkoutPerRoutineVO findWorkoutPerRoutineByCode(Long workoutPerRoutineCode);
 
     // 루틴 코드별 우동별 루틴 조회
-    ResponseFindWorkoutPerRoutineVO findWorkoutPerRoutineByRoutineCode(Long routineCode);
+    List<ResponseFindWorkoutPerRoutineVO> findWorkoutPerRoutineByRoutineCode(Long routineCode);
 
     @Transactional
     ResponseInsertWorkoutPerRoutineVO registerWorkoutPerRoutine(WorkoutPerRoutineDTO workoutPerRoutineDTO);

--- a/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/service/WorkoutPerRoutineServiceImpl.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/workout_per_routine/service/WorkoutPerRoutineServiceImpl.java
@@ -51,12 +51,13 @@ public class  WorkoutPerRoutineServiceImpl implements WorkoutPerRoutineService {
         return modelMapper.map(routine, ResponseFindWorkoutPerRoutineVO.class);
     }
 
-    // 루틴 코드별 우동별 루틴 조회
+    // 루틴 코드별 운동별 루틴 조회
     @Override
-    public ResponseFindWorkoutPerRoutineVO findWorkoutPerRoutineByRoutineCode(Long routineCode) {
-        WorkoutPerRoutine routine = workoutPerRoutineRepository.findById(routineCode)
-                .orElseThrow(() -> new CommonException(StatusEnum.ROUTINE_NOT_FOUND));
-        return modelMapper.map(routine, ResponseFindWorkoutPerRoutineVO.class);
+    public List<ResponseFindWorkoutPerRoutineVO> findWorkoutPerRoutineByRoutineCode(Long routineCode) {
+        List<WorkoutPerRoutine> routinesList = workoutPerRoutineRepository.findByRoutineCode_RoutineCode(routineCode);
+        return routinesList.stream()
+                .map(routine -> modelMapper.map(routine, ResponseFindWorkoutPerRoutineVO.class))
+                .collect(Collectors.toList());
     }
 
     // 운동 루틴별 운동 등록

--- a/healthtart/src/main/java/com/dev5ops/healthtart/workoutinfo/controller/WorkoutInfoController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/workoutinfo/controller/WorkoutInfoController.java
@@ -42,7 +42,7 @@ public class WorkoutInfoController {
         return new ResponseEntity<>(workoutInfo, HttpStatus.OK);
     }
 
-    @GetMapping("/{RoutineCode}")
+    @GetMapping("/datail/{RoutineCode}")
     @Operation(summary = "루틴 코드별 운동 정보 단일 조회")
     public ResponseEntity<ResponseFindWorkoutInfoVO> getWorkoutInfoByRoutineCode(@PathVariable Long routineCode) {
         ResponseFindWorkoutInfoVO workoutInfo = workoutInfoService.findWorkoutInfoByCode(routineCode);


### PR DESCRIPTION
- 제목 : feat(#43 ): WorkoutPerRoutineController, Service, ServiceImpl 타입 변경, WorkoutInfoController 루틴코드별 운동정보 단일 조회 Mapping 경로 변경 
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 1.WorkoutInfoController 루틴코드별 운동정보의 Mapping경로가 운동정보코드별 운동정보 조회와 겹쳐서 경로 수정했습니다.
- 2. 반환 타입과 일치하지 않아서 VO -> List<VO>로 변경, Service 메서드 findWorkoutPerRoutineByCode에서 findById -> findByRoutineCode_RoutineCode 사용 변경 했습니다.

  <br/>

![image](https://github.com/user-attachments/assets/398df04d-c0de-4b11-ac2f-f294580483fc)

<br/>

## 🔧 앞으로의 과제

- 프론트엔드 페이지 구현

  <br/>
