### PR TITLE
✨ feat: 카카오 OAuth 로그인 연동 (백엔드 인증 처리 → 프론트 JWT 반환 및 저장 흐름 완성)

### DIFF
--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/JwtFilter.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/JwtFilter.java
@@ -24,7 +24,8 @@ public class JwtFilter extends OncePerRequestFilter {
     private final List<String> excludeUrl
             = Arrays.asList("/users/verification-email/**"
             , "/users/nickname/check", "/users/verification-email/password", "/swagger-ui.html", "/swagger-ui/index.html"
-            , "/users/password");
+            , "/users/password"
+            , "/api/oauth/kakao");
 
     public JwtFilter(UserService userService, JwtUtil jwtUtil) {
         this.userService = userService;
@@ -34,6 +35,7 @@ public class JwtFilter extends OncePerRequestFilter {
     // security 이전에 실행되는 JwtFilter에서 제외할 url 설정
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String servletPath = request.getServletPath();
         return excludeUrl.stream()
                 .anyMatch(pattern -> new AntPathMatcher().match(pattern, request.getServletPath()));
     }

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/JwtUtil.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.dev5ops.healthtart.security;
 
 import com.dev5ops.healthtart.user.domain.CustomUserDetails;
+import com.dev5ops.healthtart.user.domain.KakaoUserProfile;
 import com.dev5ops.healthtart.user.domain.dto.JwtTokenDTO;
 import com.dev5ops.healthtart.user.domain.dto.UserDTO;
 import io.jsonwebtoken.*;
@@ -60,9 +61,6 @@ public class JwtUtil {
         /* 설명. 토큰에서 claim들 추출 */
         Claims claims = parseClaims(token);
         log.info("넘어온 AccessToken claims 확인: {}", claims);
-
-        // JWT 토큰에서 subject를 가져와 사용자 ID로 사용
-//        String userId = claims.getSubject();
 
         Collection<? extends GrantedAuthority> authorities = null;
         if (claims.get("roles") == null) {
@@ -130,6 +128,28 @@ public class JwtUtil {
                 .signWith(SignatureAlgorithm.HS512, secretKey)
                 .compact();
     }
+
+    public String generateTokenFromKakaoUser(KakaoUserProfile profile, String userCode) {
+        // 1. 카카오 사용자 정보 추출
+        Long kakaoId = profile.getId();
+        String email = profile.getKakao_account().getEmail();
+        String nickname = profile.getKakao_account().getProfile().getNickname();
+
+        // 3. DTO 구성
+        JwtTokenDTO tokenDTO = new JwtTokenDTO(
+                userCode,
+                email,
+                nickname
+        );
+
+        // 4. 기본 역할 설정
+        List<String> roles = List.of("MEMBER");
+
+        // 5. 토큰 생성 (provider는 "kakao" 명시)
+        return generateToken(tokenDTO, roles, "kakao");
+    }
+
+
 
     public String getEmailFromToken(String token) {
         return getClaimFromToken(token, claims -> claims.get("email", String.class));

--- a/healthtart/src/main/java/com/dev5ops/healthtart/security/WebSecurity.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/security/WebSecurity.java
@@ -61,6 +61,7 @@ public class WebSecurity {
         // HttpSecurity 설정
         http.authorizeHttpRequests((authz) ->
                         authz
+                                .requestMatchers(new AntPathRequestMatcher("/api/oauth/kakao", "POST")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/error")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/swagger-ui/index.html", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**", "GET")).permitAll()
@@ -134,7 +135,9 @@ public class WebSecurity {
 //                        .failureHandler(new OAuth2AuthenticationFailureHandler())
                 )
 
-                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                .sessionManagement((session)
+                        -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
         // JWT 인증 필터 추가
         http.addFilter(getAuthenticationFilter(authenticationManager));
         http.addFilterBefore(new JwtFilter(userService, jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserOauthController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserOauthController.java
@@ -1,0 +1,29 @@
+package com.dev5ops.healthtart.user.controller;
+
+import com.dev5ops.healthtart.user.service.KakaoOauthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/oauth")
+@RequiredArgsConstructor
+public class UserOauthController {
+
+    private final KakaoOauthService kakaoOauthService;
+
+    @PostMapping("/kakao")
+    public Map<String, String> kakaoLogin(@RequestBody Map<String, String> body) {
+        String code = body.get("code");
+        String jwt = kakaoOauthService.loginWithKakao(code);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("token", jwt);
+        return response;
+    }
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserOauthController.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/controller/UserOauthController.java
@@ -20,7 +20,8 @@ public class UserOauthController {
     @PostMapping("/kakao")
     public Map<String, String> kakaoLogin(@RequestBody Map<String, String> body) {
         String code = body.get("code");
-        String jwt = kakaoOauthService.loginWithKakao(code);
+        String codeVerifier = body.get("codeVerifier");
+        String jwt = kakaoOauthService.loginWithKakao(code, codeVerifier);
 
         Map<String, String> response = new HashMap<>();
         response.put("token", jwt);

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/KakaoUserProfile.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/domain/KakaoUserProfile.java
@@ -1,0 +1,22 @@
+package com.dev5ops.healthtart.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUserProfile {
+    private Long id; // 사용자 고유 ID
+    private KakaoAccount kakao_account;
+
+    @Getter
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+
+        @Getter
+        public static class Profile {
+            private String nickname;
+            private String profile_image_url;
+            private String thumbnail_image_url;
+        }
+    }
+}

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/service/KakaoOauthService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/service/KakaoOauthService.java
@@ -35,10 +35,10 @@ public class KakaoOauthService {
     private final RestTemplate restTemplate; // 또는 WebClient
     private final JwtUtil jwtUtil;
 
-    public String loginWithKakao(String code) {
+    public String loginWithKakao(String code, String codeVerifier) {
 
         // 1. 인가코드로 카카오 access_token 요청
-        String kakaoAccessToken = requestAccessToken(code);
+        String kakaoAccessToken = requestAccessToken(code, codeVerifier);
 
         // 2. access_token으로 사용자 정보 요청
         KakaoUserProfile profile = requestUserProfile(kakaoAccessToken);
@@ -62,7 +62,7 @@ public class KakaoOauthService {
     }
 
     // access_token 요청
-    private String requestAccessToken(String code) {
+    private String requestAccessToken(String code, String codeVerifier) {
         String tokenUri = "https://kauth.kakao.com/oauth/token";
 
         HttpHeaders headers = new HttpHeaders();
@@ -74,6 +74,7 @@ public class KakaoOauthService {
         params.add("client_secret", kakaoClientSecret);
         params.add("redirect_uri", kakaoRedirectUri); // 프론트 redirect URI
         params.add("code", code);
+        params.add("code_verifier", codeVerifier);
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 

--- a/healthtart/src/main/java/com/dev5ops/healthtart/user/service/KakaoOauthService.java
+++ b/healthtart/src/main/java/com/dev5ops/healthtart/user/service/KakaoOauthService.java
@@ -1,0 +1,138 @@
+package com.dev5ops.healthtart.user.service;
+
+import com.dev5ops.healthtart.security.JwtUtil;
+import com.dev5ops.healthtart.user.domain.KakaoUserProfile;
+import com.dev5ops.healthtart.user.domain.UserTypeEnum;
+import com.dev5ops.healthtart.user.domain.entity.UserEntity;
+import com.dev5ops.healthtart.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthService {
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate; // 또는 WebClient
+    private final JwtUtil jwtUtil;
+
+    public String loginWithKakao(String code) {
+
+        // 1. 인가코드로 카카오 access_token 요청
+        String kakaoAccessToken = requestAccessToken(code);
+
+        // 2. access_token으로 사용자 정보 요청
+        KakaoUserProfile profile = requestUserProfile(kakaoAccessToken);
+        String email = profile.getKakao_account().getEmail();
+        String nickname = profile.getKakao_account().getProfile().getNickname();
+        String kakaoId = String.valueOf(profile.getId());
+        String provider = "kakao";
+        String providerId = kakaoId;
+
+        // 3. DB에 사용자 존재 여부 확인 및 저장
+        UserEntity user = userRepository.findByProviderAndProviderId(provider, providerId);
+        String userCode = (user != null) ? user.getUserCode()
+                : saveNewKakaoUser(email, nickname, provider, providerId);
+
+        // 4. JWT 발급 및 인증 객체 등록
+        String token = jwtUtil.generateTokenFromKakaoUser(profile, userCode);
+        Authentication authentication = jwtUtil.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return token;
+    }
+
+    // access_token 요청
+    private String requestAccessToken(String code) {
+        String tokenUri = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("client_secret", kakaoClientSecret);
+        params.add("redirect_uri", kakaoRedirectUri); // 프론트 redirect URI
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(tokenUri, request, Map.class);
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            Map body = response.getBody();
+            return (String) body.get("access_token");
+        } else {
+            throw new RuntimeException("카카오 access_token 요청 실패: " + response.getStatusCode());
+        }
+    }
+
+    // 사용자 정보 요청
+    private KakaoUserProfile requestUserProfile(String accessToken) {
+        String userInfoUri = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken); // Authorization: Bearer {accessToken}
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoUserProfile> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                KakaoUserProfile.class
+        );
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            return response.getBody();
+        } else {
+            throw new RuntimeException("카카오 사용자 정보 요청 실패: " + response.getStatusCode());
+        }
+    }
+
+    private String saveNewKakaoUser(String email, String nickname, String provider, String providerId) {
+        String curDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uuid = UUID.randomUUID().toString();
+        String userCode = curDate + "-" + uuid.substring(0);
+
+        UserEntity user = UserEntity.builder()
+                .userCode(userCode)
+                .userType(UserTypeEnum.MEMBER)
+                .userName(nickname)
+                .userEmail(email)
+                .userPassword(null)
+                .userPhone(null)
+                .userNickname(null)
+                .userAddress(null)
+                .userFlag(true)
+                .provider(provider)
+                .providerId(providerId)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        userRepository.save(user);
+        return userCode;
+    }
+}
+


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
1. 스프링 시큐리티를 통한 전체 OAuth 2.0 인증처리 대신 프론트에서 요청하게 수정
2. 시큐리티를 거치지 않기 때문에 SecurityContext에 자체적으로 Authentication 객체 추가

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
1. 프론트 OAuth 2.0 인가코드 교환 시에 PKCE 추가

  <br/>
